### PR TITLE
ol_singleton.c: Adding #include <stdint.h>

### DIFF
--- a/src/ol_singleton.c
+++ b/src/ol_singleton.c
@@ -27,6 +27,9 @@
 #include "ol_singleton.h"
 #include "config.h"
 #include "ol_debug.h"
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
 
 const char *LOCK_FILENAME = "singleton.lock";
 


### PR DESCRIPTION
ol_singleton.c missing including stdint.h and causes FTBFS
on Debian. We add #include <stdint.h> based on config.h

Signed-off-by: Ying-Chun Liu (PaulLiu) paulliu@debian.org
