### PR TITLE
Skip the daemon's name when detecting MPRIS2 players.

### DIFF
--- a/daemon/main.py
+++ b/daemon/main.py
@@ -24,17 +24,14 @@ import dbus
 
 from osdlyrics.app import AlreadyRunningException, App
 from osdlyrics.consts import (CONFIG_BUS_NAME, DAEMON_BUS_NAME,
-                              MPRIS2_OBJECT_PATH)
+                              DAEMON_INTERFACE, DAEMON_MPRIS2_NAME,
+                              DAEMON_OBJECT_PATH, MPRIS2_OBJECT_PATH)
 from osdlyrics.metadata import Metadata
 
 import config
 import lyrics
 import lyricsource
 import player
-
-APP_MPRIS2_NAME = 'org.mpris.MediaPlayer2.osdlyrics'
-DAEMON_INTERFACE = 'org.osdlyrics.Daemon'
-DAEMON_OBJECT_PATH = '/org/osdlyrics/Daemon'
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -57,7 +54,7 @@ class MainApp(App):
         self._lyrics = lyrics.LyricsService(self.connection)
         self._connect_metadata_signal()
         self._activate_config()
-        self.request_bus_name(APP_MPRIS2_NAME)
+        self.request_bus_name(DAEMON_MPRIS2_NAME)
         self._daemon_object = DaemonObject(self)
         self._lyricsource = lyricsource.LyricSource(self.connection)
         self._lyrics.set_current_metadata(Metadata.from_dict(self._player.current_player.Metadata))

--- a/players/mpris2/mpris2.py
+++ b/players/mpris2/mpris2.py
@@ -58,8 +58,10 @@ class ProxyObject(BasePlayerProxy):
         Arguments:
         - `names`: list of bus names
         """
-        return [player_info_from_name(name[len(MPRIS2_PREFIX):]) for name in names
-                if name.startswith(MPRIS2_PREFIX)]
+        return [player_info_from_name(name[len(MPRIS2_PREFIX):])
+                for name in names if name.startswith(MPRIS2_PREFIX) and
+                # skip self: APP_MPRIS2_NAME (in daemon/main.py)
+                not name.endswith('osdlyrics')]
 
     def do_list_active_players(self):
         return self._get_player_from_bus_names(self.connection.list_names())

--- a/players/mpris2/mpris2.py
+++ b/players/mpris2/mpris2.py
@@ -24,14 +24,13 @@ import dbus
 import dbus.service
 import dbus.types
 
-from osdlyrics.consts import MPRIS2_OBJECT_PATH, MPRIS2_PLAYER_INTERFACE
+from osdlyrics.consts import (DAEMON_MPRIS2_NAME, MPRIS2_OBJECT_PATH,
+                              MPRIS2_PLAYER_INTERFACE, MPRIS2_PREFIX)
 from osdlyrics.metadata import Metadata
 from osdlyrics.player_proxy import (
     BasePlayer, BasePlayerProxy, PlayerInfo, CAPS_NEXT, CAPS_PAUSE, CAPS_PLAY,
     CAPS_PREV, CAPS_SEEK, REPEAT_ALL, REPEAT_NONE, REPEAT_TRACK, STATUS_PAUSED,
     STATUS_PLAYING, STATUS_STOPPED)
-
-MPRIS2_PREFIX = 'org.mpris.MediaPlayer2.'
 
 
 def player_info_from_name(name):
@@ -60,8 +59,7 @@ class ProxyObject(BasePlayerProxy):
         """
         return [player_info_from_name(name[len(MPRIS2_PREFIX):])
                 for name in names if name.startswith(MPRIS2_PREFIX) and
-                # skip self: APP_MPRIS2_NAME (in daemon/main.py)
-                not name.endswith('osdlyrics')]
+                name != DAEMON_MPRIS2_NAME]
 
     def do_list_active_players(self):
         return self._get_player_from_bus_names(self.connection.list_names())

--- a/python/consts.py
+++ b/python/consts.py
@@ -18,9 +18,13 @@
 # along with OSD Lyrics.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# DBus names, interfaces and object paths
-
+# D-Bus names, interfaces and object paths
+DAEMON_INTERFACE = 'org.osdlyrics.Daemon'
 DAEMON_BUS_NAME = 'org.osdlyrics.Daemon'
+DAEMON_OBJECT_PATH = '/org/osdlyrics/Daemon'
+MPRIS2_PREFIX = 'org.mpris.MediaPlayer2.'
+DAEMON_MPRIS2_NAME = 'org.mpris.MediaPlayer2.osdlyrics'
+
 CONFIG_BUS_NAME = 'org.osdlyrics.Config'
 CONFIG_OBJECT_PATH = '/org/osdlyrics/Config'
 PLAYER_PROXY_INTERFACE = 'org.osdlyrics.PlayerProxy'


### PR DESCRIPTION
The daemon's name ("org.mpris.MediaPlayer2.osdlyrics", defined as APP_MPRIS2_NAME in daemon/main.py) has the same prefix as MPRIS2 players.

It makes sense to skip it so we do not wait at the start if no player is actually running.