### PR TITLE
PEP8 fixes in daemon/main.py and basic Python 3 compatibility for MPRIS1/2 and on-disk lyrics

### DIFF
--- a/daemon/lyrics.py
+++ b/daemon/lyrics.py
@@ -24,6 +24,7 @@ import os.path
 import re
 import urllib
 import urlparse
+import sys
 
 import dbus
 import dbus.service
@@ -91,6 +92,14 @@ def metadata_description(metadata):
     else:
         return '[Unknown]'
 
+
+# TODO: remove once we have fully migrated to Python 3
+if sys.version_info >= (3, 0):
+    UNICODE_TYPE = str
+else:
+    UNICODE_TYPE = unicode
+
+
 def decode_by_charset(content):
     r"""
     Detect the charset encoding of a string and decodes to unicode strings.
@@ -100,7 +109,7 @@ def decode_by_charset(content):
     >>> decode_by_charset(u'\u4e2d\u6587'.encode('HZ-GB-2312'))
     u'\u4e2d\u6587'
     """
-    if not isinstance(content, str):
+    if isinstance(content, UNICODE_TYPE):
         return content
     encoding = chardet.detect(content)['encoding']
     # Sometimes, the content is well encoded but the last few bytes. This is

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -35,6 +35,7 @@ import player
 
 logging.basicConfig(level=logging.WARNING)
 
+
 class InvalidClientNameException(Exception):
     """ The client bus name in Hello is invalid
     """
@@ -47,6 +48,7 @@ class InvalidClientNameException(Exception):
         """
         Exception.__init__(self, 'Client bus name %s is invalid' % name)
 
+
 class MainApp(App):
     def __init__(self, ):
         App.__init__(self, 'Daemon', False)
@@ -57,13 +59,14 @@ class MainApp(App):
         self.request_bus_name(DAEMON_MPRIS2_NAME)
         self._daemon_object = DaemonObject(self)
         self._lyricsource = lyricsource.LyricSource(self.connection)
-        self._lyrics.set_current_metadata(Metadata.from_dict(self._player.current_player.Metadata))
+        self._lyrics.set_current_metadata(Metadata.from_dict(
+            self._player.current_player.Metadata))
 
     def _connect_metadata_signal(self, ):
         self._mpris_proxy = self.connection.get_object(DAEMON_BUS_NAME,
                                                        MPRIS2_OBJECT_PATH)
-        self._metadata_signal = self._mpris_proxy.connect_to_signal('PropertiesChanged',
-                                                                    self._player_properties_changed)
+        self._metadata_signal = self._mpris_proxy.connect_to_signal(
+            'PropertiesChanged', self._player_properties_changed)
 
     def _activate_config(self, ):
         try:
@@ -73,7 +76,9 @@ class MainApp(App):
 
     def _player_properties_changed(self, iface, changed, invalidated):
         if 'Metadata' in changed:
-            self._lyrics.set_current_metadata(Metadata.from_dict(changed['Metadata']))
+            self._lyrics.set_current_metadata(Metadata.from_dict(
+                changed['Metadata']))
+
 
 def is_valid_client_bus_name(name):
     """Check if a client bus name is valid.
@@ -103,10 +108,12 @@ class DaemonObject(dbus.service.Object):
     def Hello(self, client_bus_name):
         logging.info('A new client connected: %s' % client_bus_name)
         if is_valid_client_bus_name(client_bus_name):
-            if not client_bus_name in self._watch_clients:
-                self._watch_clients[client_bus_name] = self.connection.watch_name_owner(
-                    client_bus_name,
-                    lambda owner: self._client_owner_changed(client_bus_name, owner))
+            if client_bus_name not in self._watch_clients:
+                self._watch_clients[client_bus_name] = \
+                    self.connection.watch_name_owner(
+                        client_bus_name,
+                        lambda owner: self._client_owner_changed(
+                            client_bus_name, owner))
         else:
             raise InvalidClientNameException(client_bus_name)
 
@@ -132,12 +139,14 @@ class DaemonObject(dbus.service.Object):
                 logging.info('All client disconnected, quit the daemon')
                 self._app.quit()
 
+
 def main():
     try:
         app = MainApp()
         app.run()
     except AlreadyRunningException:
-        print 'OSD Lyrics is running'
+        print('OSD Lyrics is running')
+
 
 if __name__ == '__main__':
     main()

--- a/python/dbusext/service.py
+++ b/python/dbusext/service.py
@@ -20,6 +20,7 @@
 
 import logging
 import xml.etree.ElementTree as xet
+import sys
 
 import dbus
 import dbus.exceptions
@@ -27,6 +28,12 @@ import dbus.service
 import glib
 
 from .property import Property
+
+
+# Use the default encoding in ElementTree.tostring under Python 2, but prefer
+# Unicode under Python 3 to obtain a 'str', not 'bytes' instance.
+# TODO: remove once we have fully migrated to Python 3
+INTROSPECT_ENCODING = 'unicode' if sys.version_info >= (3, 0) else 'us-ascii'
 
 
 class ObjectTypeCls(dbus.service.Object.__class__):
@@ -204,7 +211,7 @@ class Object(ObjectType):
                 iface.append(_property2element(prop))
             node.append(iface)
         return '<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"\n "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">\n' + \
-            xet.tostring(node)
+            xet.tostring(node, encoding=INTROSPECT_ENCODING)
 
 
 def property(type_signature,

--- a/python/lrc.py
+++ b/python/lrc.py
@@ -141,7 +141,7 @@ def parse_lrc(content):
                 lyrics.append({ 'timestamp': dbus.types.Int64(timestamp),
                                 'text': token.text })
             timetags = []
-    lyrics.sort(lambda a,b: cmp(a['timestamp'], b['timestamp']))
+    lyrics.sort(key=lambda a: a['timestamp'])
     i = 0
     for lyric in lyrics:
         lyric['id'] = dbus.types.UInt32(i)

--- a/python/utils.py
+++ b/python/utils.py
@@ -103,21 +103,27 @@ def path2uri(path):
         path = path.encode('utf8')
     return 'file://' + urllib.pathname2url(path)
 
-def ensure_unicode(value):
-    r"""
-    If value is a string, decode with utf-8. Otherwise return it directly.
-    """
-    if isinstance(value, str):
-        return value.decode('utf8')
-    return value
 
-def ensure_utf8(value):
-    r"""
-    If value is a unicode, encode with utf-8. Otherwise return it directly.
-    """
-    if isinstance(value, unicode):
-        return value.encode('utf8')
-    return value
+# TODO: remove once we fully migrate to Python 3
+if sys.version_info < (3, 0):
+    def ensure_unicode(value):
+        r"""
+        If value is a string, decode with utf-8. Otherwise return it directly.
+        """
+        if isinstance(value, str):
+            return value.decode('utf8')
+        return value
+
+    def ensure_utf8(value):
+        r"""
+        If value is a unicode, encode with utf-8. Otherwise return it directly.
+        """
+        if isinstance(value, str):
+            return value.encode('utf8')
+        return value
+else:
+    ensure_unicode = ensure_utf8 = lambda s: s
+
 
 def get_proxy_settings(config=None, conn=None):
     r"""


### PR DESCRIPTION
These patches make OSD Lyrics work under both Python 2 and 3.
Functionality tested: MPRIS1 (MOC), MPRIS2 (VLC), cached lyrics.
Not working: downloading of lyrics and probably other things I did not test.

To build, I changed my PKGBUILD to run these commands in the source directory:
```
2to3 --write --nobackups .
# ./autogen.sh
autoreconf --install --force
./configure --prefix=/usr PYTHON=/usr/bin/python3 --enable-appindicator=no
make
```

`2to3` handled conversion of the code in place. Instead of `autogen.sh`, which enforces Python 2 and merely runs `autoreconf --install --force`, I simply took out the command. `--enable-appindicator=no` silences these warnings: `(OSD Lyrics:22821): libappindicator-WARNING **: Unable to connect to the Notification Watcher: GDBus.Error:org.kde.StatusNotifierWatcher.Item.AlreadyRegistered:`

This addresses a part of https://github.com/osdlyrics/osdlyrics/issues/10