### PR TITLE
Fix deprecated function calls and unused variable causing FTFBS with -Werror

### DIFF
--- a/src/ol_osd_window.c
+++ b/src/ol_osd_window.c
@@ -45,7 +45,6 @@ static const OlColor DEFAULT_ACTIVE_COLORS[OL_LINEAR_COLOR_COUNT]= {
 };
 static const int MOUSE_TIMER_INTERVAL = 100;
 
-static const int DEFAULT_LINE_HEIGHT = 45;
 static const int DEFAULT_HEIGHT = 100;
 static const double LINE_PADDING = 0.0;
 static const int BORDER_WIDTH = 5;

--- a/src/tests/ol_app_info_test.c
+++ b/src/tests/ol_app_info_test.c
@@ -189,7 +189,6 @@ second_exe_test (void)
 int
 main (int argc, char **argv)
 {
-  g_type_init ();
   init ();
   basic_test ();
   desktop_test ();

--- a/src/tests/ol_lyric_source_test.c
+++ b/src/tests/ol_lyric_source_test.c
@@ -263,7 +263,6 @@ test_empty_source (void)
 int
 main (int argc, char **argv)
 {
-  g_type_init ();
   source = ol_lyric_source_new ();
   test_list_sources ();
   test_search ();

--- a/src/tests/ol_utils_dbus_test.c
+++ b/src/tests/ol_utils_dbus_test.c
@@ -38,7 +38,6 @@ test_prop ()
 int
 main ()
 {
-  g_type_init ();
   test_list_name ();
   test_prop ();
   return 0;

--- a/src/tests/ol_utils_test.c
+++ b/src/tests/ol_utils_test.c
@@ -83,7 +83,6 @@ test_traverse (void)
 int
 main (int argc, char **argv)
 {
-  g_type_init ();
   ol_log_set_file ("-");
   test_hashtable ();
   test_traverse ();


### PR DESCRIPTION
This fixes some warnings that cause the build to fail when -Werror is set:
- `g_type_init()` has been deprecated since GLib 2.36 and is now implied: https://developer.gnome.org/gobject/stable/gobject-Type-Information.html#g-type-init
- The `DEFAULT_LINE_HEIGHT` variable is defined in ol_osd_window.c but never used.