### PR TITLE
Use ChangeLog date instead of build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ m4_define([OL_MINOR_VER], [5])
 m4_define([OL_MICRO_VER], [0])
 m4_define([OL_BUILD], [-git])
 m4_define(OL_BUILD_VER,
-          m4_esyscmd_s([if test 'x]OL_BUILD[' = 'x-git'; then (git log -1 --format=format:%ad --date=short 2>/dev/null || date +%Y%m%d) | sed 's/-//g'; fi]))
+          m4_esyscmd_s([if test 'x]OL_BUILD[' = 'x-git'; then (git log -1 --format=format:%ad --date=short 2>/dev/null || date -u -r ChangeLog +%Y%m%d) | sed 's/-//g'; fi]))
 
 m4_define([OL_VERSION], [OL_MAJOR_VER.OL_MINOR_VER.OL_MICRO_VER[]OL_BUILD[]OL_BUILD_VER])
 AC_INIT([osdlyrics], [OL_VERSION], [https://github.com/osdlyrics/osdlyrics/issues])


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

This date call works with GNU date and BSD date.

Without this patch, the osdlyrics openSUSE package would differ
for every build

```diff
/usr/lib64/osdlyrics/daemon/config.py differs (ASCII text) 
--- old//usr/lib64/osdlyrics/daemon/config.py   2017-11-26 12:00:00.000000000 +0000 
+++ new//usr/lib64/osdlyrics/daemon/config.py   2017-11-26 12:00:00.000000000 +0000
@@ -20,4 +20,4 @@

 PROGRAM_NAME = '@PROGRAM_NAME@'
 PACKAGE_NAME = 'osdlyrics'
-PACKAGE_VERSION = '0.5.0-git20171128'
+PACKAGE_VERSION = '0.5.0-git20190103'

and differ in /usr/bin/osdlyrics accordingly