### PR TITLE
Fix some display bugs when changing song while stopped

### DIFF
--- a/src/ol_osd_module.c
+++ b/src/ol_osd_module.c
@@ -45,7 +45,6 @@ struct _OlOsdModule
   gint current_line;
   gint line_count;
   OlLrc *lrc;
-  gboolean display;
   OlOsdWindow *window;
   OlOsdToolbar *toolbar;
   guint message_source;
@@ -507,7 +506,6 @@ ol_osd_module_init_osd (OlOsdModule *osd)
     g_object_ref (osd->toolbar);
     ol_osd_toolbar_set_player (osd->toolbar, osd->player);
   }
-  osd->display = FALSE;
   OlConfigProxy *config = ol_config_proxy_get_instance ();
   ol_assert (config != NULL);
   
@@ -698,8 +696,6 @@ ol_osd_module_set_lrc (struct OlDisplayModule *module, OlLrc *lrc_file)
   {
     clear_lyrics (priv);
   }
-  /* if (lrc_file != NULL) */
-  /*   module->display = TRUE; */
 }
 
 static void
@@ -764,7 +760,6 @@ clear_lyrics (OlOsdModule *osd)
   ol_log_func ();
   if (osd->window != NULL && osd->message_source == 0)
   {
-    osd->display = FALSE;
     /* gtk_widget_hide (GTK_WIDGET (module->window)); */
     ol_osd_window_set_lyric (osd->window, 0, NULL);
     ol_osd_window_set_lyric (osd->window, 1, NULL);

--- a/src/ol_osd_module.c
+++ b/src/ol_osd_module.c
@@ -611,8 +611,6 @@ _update_metadata (OlOsdModule *module)
   ol_log_func ();
   ol_assert (module != NULL);
   ol_player_get_metadata (module->player, module->metadata);
-  clear_lyrics (module);
-  hide_message (module);
 }
 
 static void
@@ -685,17 +683,21 @@ ol_osd_module_set_lrc (struct OlDisplayModule *module, OlLrc *lrc_file)
   ol_assert (priv != NULL);
   if (priv->lrc)
     g_object_unref (priv->lrc);
-  priv->lrc = lrc_file;
   if (lrc_file)
     g_object_ref (lrc_file);
-  if (lrc_file != NULL && priv->message_source != 0)
+
+  if (priv->message_source != 0)
   {
+    /* A message can only be displayed if no lyrics are currently assigned. */
+    ol_assert (priv->lrc == NULL);
     ol_osd_module_clear_message (module);
   }
-  if (lrc_file == NULL && priv->message_source == 0)
+  else if (lrc_file == NULL)
   {
     clear_lyrics (priv);
   }
+
+  priv->lrc = lrc_file;
 }
 
 static void
@@ -746,10 +748,8 @@ hide_message (OlOsdModule *osd)
 {
   ol_log_func ();
   ol_assert_ret (osd != NULL, FALSE);
-  if (osd->lrc != NULL)
-    return FALSE;
+  ol_assert_ret (osd->lrc == NULL, FALSE);
   ol_osd_window_set_lyric (osd->window, 0, NULL);
-  /* gtk_widget_hide (GTK_WIDGET (module->window)); */
   osd->message_source = 0;
   return FALSE;
 }
@@ -760,7 +760,6 @@ clear_lyrics (OlOsdModule *osd)
   ol_log_func ();
   if (osd->window != NULL && osd->message_source == 0)
   {
-    /* gtk_widget_hide (GTK_WIDGET (module->window)); */
     ol_osd_window_set_lyric (osd->window, 0, NULL);
     ol_osd_window_set_lyric (osd->window, 1, NULL);
   }

--- a/src/ol_osd_module.c
+++ b/src/ol_osd_module.c
@@ -108,7 +108,8 @@ static void ol_osd_module_update_next_lyric (OlOsdModule *osd,
 static void ol_osd_module_init_osd (OlOsdModule *osd);
 static gboolean hide_message (OlOsdModule *osd);
 static gboolean is_message_displayed (OlOsdModule *osd);
-static void clear_lyrics (OlOsdModule *osd);
+static void reset_lyrics_state (OlOsdModule *osd);
+static void hide_lyrics (OlOsdModule *osd);
 
 /* OSD Window signal handlers */
 static void ol_osd_moved_handler (OlOsdWindow *osd, gpointer data);
@@ -536,9 +537,7 @@ ol_osd_module_new (struct OlDisplayModule *module,
   data->player = player;
   data->window = NULL;
   data->lrc = NULL;
-  data->lrc_id = -1;
-  data->lrc_next_id = -1;
-  data->current_line = 0;
+  reset_lyrics_state (data);
   data->message_source = 0;
   data->metadata = ol_metadata_new ();
   data->config_bindings = NULL;
@@ -658,7 +657,8 @@ ol_osd_module_set_played_time (struct OlDisplayModule *module,
     }
     else if (priv->lrc_id != -1)
     {
-      clear_lyrics (priv);
+      hide_lyrics (priv);
+      reset_lyrics_state (priv);
     }
     ol_lrc_iter_free (iter);
   }
@@ -695,10 +695,11 @@ ol_osd_module_set_lrc (struct OlDisplayModule *module, OlLrc *lrc_file)
   }
   else if (lrc_file == NULL)
   {
-    clear_lyrics (priv);
+    hide_lyrics (priv);
   }
 
   priv->lrc = lrc_file;
+  reset_lyrics_state (priv);
 }
 
 static void
@@ -763,7 +764,15 @@ is_message_displayed (OlOsdModule *osd)
 }
 
 static void
-clear_lyrics (OlOsdModule *osd)
+reset_lyrics_state (OlOsdModule *osd)
+{
+  osd->current_line = 0;
+  osd->lrc_id = -1;
+  osd->lrc_next_id = -1;
+}
+
+static void
+hide_lyrics (OlOsdModule *osd)
 {
   ol_log_func ();
   if (osd->window != NULL && !is_message_displayed (osd))
@@ -771,9 +780,6 @@ clear_lyrics (OlOsdModule *osd)
     ol_osd_window_set_lyric (osd->window, 0, NULL);
     ol_osd_window_set_lyric (osd->window, 1, NULL);
   }
-  osd->current_line = 0;
-  osd->lrc_id = -1;
-  osd->lrc_next_id = -1;
 }
 
 static void

--- a/src/ol_osd_module.c
+++ b/src/ol_osd_module.c
@@ -44,6 +44,7 @@ struct _OlOsdModule
   gint lrc_next_id;
   gint current_line;
   gint line_count;
+  gboolean force_refresh_on_set_played_time;
   OlLrc *lrc;
   OlOsdWindow *window;
   OlOsdToolbar *toolbar;
@@ -538,6 +539,7 @@ ol_osd_module_new (struct OlDisplayModule *module,
   data->window = NULL;
   data->lrc = NULL;
   reset_lyrics_state (data);
+  data->force_refresh_on_set_played_time = FALSE;
   data->message_source = 0;
   data->metadata = ol_metadata_new ();
   data->config_bindings = NULL;
@@ -655,12 +657,14 @@ ol_osd_module_set_played_time (struct OlDisplayModule *module,
       if (percentage > 0.5 && priv->lrc_next_id == -1)
         ol_osd_module_update_next_lyric (priv, iter);
     }
-    else if (priv->lrc_id != -1)
+    else if (priv->lrc_id != -1 || priv->force_refresh_on_set_played_time)
     {
       hide_lyrics (priv);
       reset_lyrics_state (priv);
     }
     ol_lrc_iter_free (iter);
+
+    priv->force_refresh_on_set_played_time = FALSE;
   }
 }
 
@@ -696,6 +700,10 @@ ol_osd_module_set_lrc (struct OlDisplayModule *module, OlLrc *lrc_file)
   else if (lrc_file == NULL)
   {
     hide_lyrics (priv);
+  }
+  else
+  {
+    priv->force_refresh_on_set_played_time = TRUE;
   }
 
   priv->lrc = lrc_file;


### PR DESCRIPTION
There are currently a number of issues that arise when changing song while the player is stopped, and this PR should fix most of them.

In fact, these issues are not just about when the player is stopped, but they only really become apparent then, because in this situation neither the OSD and nor the scroll module refreshes the displayed lyrics/message.

198fc18 is the important commit, because it fixes a bug where the source ID of the timer used to clear the displayed message is not cleared correctly, which has rather unpredictable consequences (most importantly that choosing "No lyric" no longer clears the OSD, which is how I found out about all this in the first place).

The last three commits clean up the interactions between set_lrc() and set_played_time(). set_lrc() now only refreshes the display when passed a null lrc_file, and set_played_time() refreshes the display as necessary. Always calling set_played_time() after set_lrc() ensures that the display is always in sync.