### PR TITLE
ol_app_info: fix path check

### DIFF
--- a/src/ol_app_info.c
+++ b/src/ol_app_info.c
@@ -460,7 +460,7 @@ _find_binfile (const gchar *binfile, gboolean match_prefix)
     gchar **pathiter;
     for (pathiter = pathv; *pathiter != NULL; pathiter++)
     {
-      if (*pathiter != '\0')
+      if (**pathiter != '\0')
         path_list = g_list_prepend (path_list, g_strdup (*pathiter));
     }
     path_list = g_list_reverse (path_list);


### PR DESCRIPTION
The current code is checking twice that the string is non-null; the
second check should rather be about the string being empty.

Fixes #42.