### PR TITLE
Fixes for netease

### DIFF
--- a/lyricsources/netease/netease.py
+++ b/lyricsources/netease/netease.py
@@ -53,7 +53,7 @@ class NeteaseSource(BaseLyricSourcePlugin):
                                 sourceid=self.id,
                                 downloadinfo=url)
 
-        parsed = json.loads(content)
+        parsed = json.loads(content.decode('utf-8'))
         result = list(map(map_func, parsed['result']['songs']))
 
         return result
@@ -69,9 +69,11 @@ class NeteaseSource(BaseLyricSourcePlugin):
         if status < 200 or status >= 400:
             raise httplib.HTTPException(status)
 
-        parsed = json.loads(content)
+        parsed = json.loads(content.decode('utf-8'))
+        if 'nolyric' in parsed:
+            raise ValueError('This item has no lyrics.')
         lyric = parsed['lrc']['lyric']
-        return lyric
+        return lyric.encode('utf-8')
 
 if __name__ == '__main__':
     netease = NeteaseSource()

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -11,4 +11,5 @@ src/ol_app_info.c
 src/ol_scroll_window.c
 data/dialogs.glade
 data/osdlyrics.desktop.in
+lyricsources/netease/netease.py
 lyricsources/xiami/xiami.py

--- a/tools/create-lyricsource.py
+++ b/tools/create-lyricsource.py
@@ -77,7 +77,7 @@ class ${capsname}Source(BaseLyricSourcePlugin):
                              downloadinfo='http://foo.bar/download?id=1')]
 
     def do_download(self, downloadinfo):
-        # return a string
+        # type: (AnyStr) -> bytes
         # downloadinfo is what you set in SearchResult
         if not isinstance(downloadinfo, str) and \
                 not isinstance(downloadinfo, unicode):


### PR DESCRIPTION
* To be consisted with other lyricsources, return lrc as `bytes`
* Add po files
* Explicit raise exception when the item has no lyrics. (Instead of an unclear `KeyError` regarding `lrc`)