### PR TITLE
Python: fix NULL ending in downloaded lrc

### DIFF
--- a/daemon/lyrics.py
+++ b/daemon/lyrics.py
@@ -372,7 +372,7 @@ class LyricsService(dbus.service.Object):
         # Remove any existing file association and save the new lyrics content
         # to the configured patterns.
         self._db.delete(metadata)
-        uri = self._save_to_patterns(metadata, content)
+        uri = self._save_to_patterns(metadata, content.rstrip('\0'))
         if uri and metadata_equal(metadata, self._metadata):
             self.CurrentLyricsChanged()
         return uri


### PR DESCRIPTION
Fix #51.

I've found that the lyrics are downloaded by Python code, then transferred to C code via DBus, then it [called](https://github.com/osdlyrics/osdlyrics/blob/master/src/ol_lyrics.c#L307) Python [code](https://github.com/osdlyrics/osdlyrics/blob/master/daemon/lyrics.py#L369) via DBus to save the file. The C code transfers an usual NUL-terminated string ("content") via DBus, and the Python code does not remove it.