### PR TITLE
Replace / in metadata with _ when expanding pattern

### DIFF
--- a/python/pattern.py
+++ b/python/pattern.py
@@ -113,7 +113,7 @@ def expand_file(pattern, metadata):
                     if not isinstance(value, str):
                         value = str(value)
                     has_tag = True
-                    parts.append(value)
+                    parts.append(value.replace('/', '_'))
             if has_tag:
                 start = end + 2
             else:


### PR DESCRIPTION
This fixes #62, only replace / with _ when expanding %t, %p, %a, %n.