### PR TITLE
0 compile-time C warnings

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -9,5 +9,5 @@ args=$@
 if [ -e /usr/bin/python2 ]; then
     args="$args PYTHON=/usr/bin/python2"
 fi
-AUTOPOINT='intltoolize' autoreconf --install --force --verbose --debug $DIR
+AUTOPOINT='intltoolize' autoreconf --install --force $DIR
 $DIR/configure $args

--- a/autogen.sh
+++ b/autogen.sh
@@ -9,5 +9,5 @@ args=$@
 if [ -e /usr/bin/python2 ]; then
     args="$args PYTHON=/usr/bin/python2"
 fi
-AUTOPOINT='intltoolize' autoreconf --install --force $DIR
+AUTOPOINT='intltoolize' autoreconf --install --force --verbose --debug $DIR
 $DIR/configure $args

--- a/src/ol_app_chooser_widget.c
+++ b/src/ol_app_chooser_widget.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2011  Tiger Soldier
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,19 +15,13 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <math.h>
 #include <string.h>
 #include "ol_app_chooser_widget.h"
 #include "ol_debug.h"
-
-#define OL_APP_CHOOSER_WIDGET_GET_PRIVATE(obj)                         \
-  (G_TYPE_INSTANCE_GET_PRIVATE                                         \
-   ((obj),                                                             \
-    OL_TYPE_APP_CHOOSER_WIDGET,                                        \
-    OlAppChooserWidgetPrivate))
 
 static const char *DEFAULT_ICON_NAME = "media-playback-start";
 static const int DEFAULT_N_COLUMN = 4;
@@ -45,6 +39,7 @@ struct _OlAppChooserWidgetPrivate
   GPtrArray *app_list;
   guint n_columns;
 };
+
 
 static guint _signals[LAST_SIGNAL];
 
@@ -65,10 +60,6 @@ G_DEFINE_TYPE (OlAppChooserWidget,
 static void
 ol_app_chooser_widget_class_init (OlAppChooserWidgetClass *klass)
 {
-  GtkObjectClass *gtkobject_class;
-
-  gtkobject_class = GTK_OBJECT_CLASS (klass);
-  gtkobject_class->destroy = ol_app_chooser_widget_destroy;
   g_type_class_add_private (G_OBJECT_CLASS (klass),
                             sizeof (OlAppChooserWidgetPrivate));
   _signals[APP_ACTIVATE_SIGNAL] =
@@ -87,7 +78,7 @@ ol_app_chooser_widget_class_init (OlAppChooserWidgetClass *klass)
 static void
 ol_app_chooser_widget_init (OlAppChooserWidget *chooser)
 {
-  OlAppChooserWidgetPrivate *priv = OL_APP_CHOOSER_WIDGET_GET_PRIVATE (chooser);
+  OlAppChooserWidgetPrivate *priv = ol_app_chooser_widget_get_instance_private (chooser);
   priv->app_list = g_ptr_array_new_with_free_func (g_object_unref);
   priv->n_columns = -1;
 }
@@ -95,13 +86,8 @@ ol_app_chooser_widget_init (OlAppChooserWidget *chooser)
 static void
 ol_app_chooser_widget_destroy (GtkObject *object)
 {
-  OlAppChooserWidgetPrivate *priv = OL_APP_CHOOSER_WIDGET_GET_PRIVATE (object);
-  if (priv->app_list)
-  {
-    g_ptr_array_free (priv->app_list, TRUE);
-    priv->app_list = NULL;
-  }
-  GTK_OBJECT_CLASS (ol_app_chooser_widget_parent_class)->destroy (object);
+  GtkObjectClass *parent_class = GTK_OBJECT_CLASS(ol_app_chooser_widget_parent_class) ;
+  parent_class->destroy (object);
 }
 
 void
@@ -110,7 +96,7 @@ ol_app_chooser_widget_set_app_list (OlAppChooserWidget *chooser,
                                     guint n_columns)
 {
   ol_assert (OL_IS_APP_CHOOSER_WIDGET (chooser));
-  OlAppChooserWidgetPrivate *priv = OL_APP_CHOOSER_WIDGET_GET_PRIVATE (chooser);
+  OlAppChooserWidgetPrivate *priv = ol_app_chooser_widget_get_instance_private (chooser);
   if (priv->app_list->len > 0)
     g_ptr_array_remove_range (priv->app_list, 0, priv->app_list->len);
   GList *iter;
@@ -177,20 +163,20 @@ _calc_size (guint count, guint *n_rows, guint *n_columns)
 static GtkWidget *
 _new_app_button (OlAppChooserWidget *chooser, guint index)
 {
-  OlAppChooserWidgetPrivate *priv = OL_APP_CHOOSER_WIDGET_GET_PRIVATE (chooser);
+  OlAppChooserWidgetPrivate *priv = ol_app_chooser_widget_get_instance_private (chooser);
   GAppInfo *info = G_APP_INFO (g_ptr_array_index (priv->app_list, index));
   if (info == NULL)
     return NULL;
   GtkWidget *image = _image_from_app_info (info);
-  
+
   GtkWidget *label = gtk_label_new (g_app_info_get_display_name (info));
   gtk_label_set_ellipsize (GTK_LABEL (label), PANGO_ELLIPSIZE_END);
   gtk_widget_set_size_request (label, LABLE_WIDTH, -1);
-  
+
   GtkWidget *vbox = gtk_vbox_new (FALSE, 0);
   gtk_box_pack_start (GTK_BOX (vbox), image, TRUE, TRUE, 0);
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, TRUE, 0);
-  
+
   GtkWidget *frame = gtk_aspect_frame_new (NULL, 0.5, 0.5, 1.0, FALSE);
   gtk_frame_set_shadow_type (GTK_FRAME (frame), GTK_SHADOW_NONE);
   gtk_container_add (GTK_CONTAINER (frame), vbox);
@@ -288,7 +274,6 @@ guint
 ol_app_chooser_widget_get_columns (OlAppChooserWidget *chooser)
 {
   ol_assert_ret (OL_IS_APP_CHOOSER_WIDGET (chooser), 0);
-  OlAppChooserWidgetPrivate *priv = OL_APP_CHOOSER_WIDGET_GET_PRIVATE (chooser);
+  OlAppChooserWidgetPrivate *priv = ol_app_chooser_widget_get_instance_private (chooser);
   return priv->n_columns;
 }
-

--- a/src/ol_app_chooser_widget.h
+++ b/src/ol_app_chooser_widget.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2011  Tiger Soldier
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,13 +15,23 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef _OL_APP_CHOOSER_WIDGET_H_
 #define _OL_APP_CHOOSER_WIDGET_H_
 
 #include <gtk/gtk.h>
+
+typedef struct {
+  GtkWidget widget;
+  GtkTable parent;
+} OlAppChooserWidget;
+
+typedef struct {
+  GtkWidgetClass widget_class;
+  GtkTableClass parent_class;
+} OlAppChooserWidgetClass;
 
 #define OL_TYPE_APP_CHOOSER_WIDGET                                      \
   ol_app_chooser_widget_get_type ()
@@ -36,27 +46,13 @@
                               OL_TYPE_APP_CHOOSER_WIDGET,               \
                               OlAppChooserWidgetClass))
 
-typedef struct _OlAppChooserWidget OlAppChooserWidget;
-typedef struct _OlAppChooserWidgetClass OlAppChooserWidgetClass;
-
-struct _OlAppChooserWidget
-{
-  GtkTable parent;
-};
-
-struct _OlAppChooserWidgetClass
-{
-  GtkTableClass parent_class;
-};
-
 GType ol_app_chooser_widget_get_type (void);
-
 GtkWidget *ol_app_chooser_widget_new (void);
 
-/** 
+/**
  * Sets the app infos to the app chooser.
- * 
- * @param chooser 
+ *
+ * @param chooser
  * @param app_list A GList of GAppInfo*.
  * @param n_columns The number of columns to show the apps. If it is set to 0, the
  *                  number of columns will be calculated according to the number
@@ -66,13 +62,13 @@ void ol_app_chooser_widget_set_app_list (OlAppChooserWidget *chooser,
                                          GList *app_list,
                                          guint n_columns);
 
-/** 
+/**
  * Gets the number of columns of displayed apps.
  *
  * The number is guaranteed to be non-zero after setting the app_list.
- * @param chooser 
- * 
- * @return 
+ * @param chooser
+ *
+ * @return
  */
 guint ol_app_chooser_widget_get_columns (OlAppChooserWidget *chooser);
 #endif /* _OL_APP_CHOOSER_WIDGET_H_ */

--- a/src/ol_cell_renderer_button.c
+++ b/src/ol_cell_renderer_button.c
@@ -14,7 +14,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <gtk/gtkprivate.h>
 #include "ol_cell_renderer_button.h"
@@ -40,7 +40,7 @@ enum {
   /* PROP_WIDTH_CHARS, */
   /* PROP_WRAP_WIDTH, */
   /* PROP_ALIGN, */
-  
+
   /* /\* Style args *\/ */
   /* PROP_BACKGROUND, */
   /* PROP_FOREGROUND, */
@@ -63,7 +63,7 @@ enum {
   /* PROP_LANGUAGE, */
   /* PROP_ELLIPSIZE, */
   /* PROP_WRAP_MODE, */
-  
+
   /* /\* Whether-a-style-arg-is-set args *\/ */
   /* PROP_BACKGROUND_SET, */
   /* PROP_FOREGROUND_SET, */
@@ -85,8 +85,6 @@ enum {
 
 static guint cell_renderer_button_signals [LAST_SIGNAL];
 
-#define OL_CELL_RENDERER_BUTTON_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), OL_TYPE_CELL_RENDERER_BUTTON, OlCellRendererButtonPrivate))
-
 typedef struct _OlCellRendererButtonPrivate OlCellRendererButtonPrivate;
 struct _OlCellRendererButtonPrivate
 {
@@ -95,14 +93,14 @@ struct _OlCellRendererButtonPrivate
   PangoEllipsizeMode ellipsize;
   PangoWrapMode wrap_mode;
   PangoAlignment align;
-  
+
   gulong populate_popup_id;
   gulong entry_menu_popdown_timeout;
   gboolean in_entry_menu;
-  
+
   gint width_chars;
   gint wrap_width;
-  
+
   GtkWidget *entry;
 };
 
@@ -157,7 +155,7 @@ ol_cell_renderer_button_init (OlCellRendererButton *cellbutton)
 {
   OlCellRendererButtonPrivate *priv;
 
-  priv = OL_CELL_RENDERER_BUTTON_GET_PRIVATE (cellbutton);
+  priv = ol_cell_renderer_button_get_instance_private (cellbutton);
 
   GTK_CELL_RENDERER (cellbutton)->xalign = 0.0;
   GTK_CELL_RENDERER (cellbutton)->yalign = 0.5;
@@ -280,15 +278,6 @@ ol_cell_renderer_button_set_property (GObject *object,
   case PROP_TEXT:
     ol_logf (OL_DEBUG, "  text\n");
     g_free (cellbutton->text);
-
-    /* if (priv->markup_set) */
-    /* { */
-    /*   if (cellbutton->extra_attrs) */
-    /*     pango_attr_list_unref (cellbutton->extra_attrs); */
-    /*   cellbutton->extra_attrs = NULL; */
-    /*   priv->markup_set = FALSE; */
-    /* } */
-
     cellbutton->text = g_strdup (g_value_get_string (value));
     g_object_notify (object, "text");
     break;
@@ -390,7 +379,7 @@ ol_cell_renderer_button_render (GtkCellRenderer      *cell,
   layout = get_layout (cellbutton, widget, TRUE, flags);
   get_size (cell, widget, cell_area, layout, &x_offset, &y_offset, NULL, NULL);
   /* ol_logf (OL_DEBUG, "  offset: (%d,%d)\n", x_offset, y_offset); */
-  if (!cell->sensitive) 
+  if (!cell->sensitive)
   {
     state |= GTK_STATE_INSENSITIVE;
   }
@@ -413,13 +402,13 @@ ol_cell_renderer_button_render (GtkCellRenderer      *cell,
       state = GTK_STATE_NORMAL;
   }
 
-  pango_layout_set_width (layout, 
+  pango_layout_set_width (layout,
                           (cell_area->width - x_offset - 2 * cell->xpad) * PANGO_SCALE);
 
   gtk_paint_layout (widget->style,
                     window,
                     state,
-        	    TRUE,
+                    TRUE,
                     expose_area,
                     widget,
                     "cellrenderertext",
@@ -427,8 +416,6 @@ ol_cell_renderer_button_render (GtkCellRenderer      *cell,
                     cell_area->y + y_offset + cell->ypad,
                     layout);
   g_object_unref (layout);
-  /* if (cell->sensitive && */
-  /*     (flags & GTK_CELL_RENDERER_PRELIT) == GTK_CELL_RENDERER_PRELIT) */
   {
     GdkPixbuf *icon = get_icon (cellbutton, widget);
     if (icon != NULL)
@@ -463,7 +450,7 @@ add_attr (PangoAttrList  *attr_list,
 {
   attr->start_index = 0;
   attr->end_index = G_MAXINT;
-  
+
   pango_attr_list_insert (attr_list, attr);
 }
 
@@ -478,8 +465,8 @@ get_layout (OlCellRendererButton *cellbutton,
   PangoLayout *layout;
   OlCellRendererButtonPrivate *priv;
 
-  priv = OL_CELL_RENDERER_BUTTON_GET_PRIVATE (cellbutton);
-  
+  priv = ol_cell_renderer_button_get_instance_private (cellbutton);
+
   layout = gtk_widget_create_pango_layout (widget, cellbutton->text);
   attr_list = pango_attr_list_new ();
   pango_layout_set_single_paragraph_mode (layout, TRUE);
@@ -515,7 +502,7 @@ get_layout (OlCellRendererButton *cellbutton,
   pango_layout_set_attributes (layout, attr_list);
 
   pango_attr_list_unref (attr_list);
-  
+
   return layout;
 }
 
@@ -534,7 +521,7 @@ get_size (GtkCellRenderer *cell,
 
   gint btn_width = (cell->xpad) * 2;
   gint btn_height = (cell->ypad) * 2;
-  
+
   GdkPixbuf *icon = get_icon (cellbutton, widget);
   if (icon != NULL)
   {
@@ -545,7 +532,7 @@ get_size (GtkCellRenderer *cell,
                    icon,
                    0,
                    &icon_x, &icon_y, &icon_width, &icon_height);
-    
+
     g_object_unref (icon);
     btn_width += icon_width;
     btn_height += icon_height;
@@ -568,71 +555,6 @@ get_size (GtkCellRenderer *cell,
     ol_logf (OL_DEBUG, "  offset: %dx%d\n", cell_area->x, cell_area->y);
   }
   ol_logf (OL_DEBUG, "  size: %dx%d\n", btn_width, btn_height);
-  /* PangoContext *context; */
-  /* PangoFontMetrics *metrics; */
-  /* PangoFontDescription *font_desc; */
-  /* gint row_height; */
-
-  /* font_desc = pango_font_description_copy_static (widget->style->font_desc); */
-  /* pango_font_description_merge_static (font_desc, cellbutton->font, TRUE); */
-
-  /* context = gtk_widget_get_pango_context (widget); */
-
-  /* metrics = pango_context_get_metrics (context, */
-  /*                                      font_desc, */
-  /*                                      pango_context_get_language (context)); */
-  /* row_height = (pango_font_metrics_get_ascent (metrics) + */
-  /*               pango_font_metrics_get_descent (metrics)); */
-  /* pango_font_metrics_unref (metrics); */
-
-  /* pango_font_description_free (font_desc); */
-
-  /* gtk_cell_renderer_set_fixed_size (cell, */
-  /*                                   cell->width, 2*cell->ypad + */
-  /*                                   PANGO_PIXELS (row_height)); */
-  /* ol_logf (OL_DEBUG, */
-  /*          "  size: %dx%d\n", */
-  /*          cell->width, */
-  /*          2*cell->ypad + */
-  /*          PANGO_PIXELS (row_height)); */
-
-  /* if (layout) */
-  /*   g_object_ref (layout); */
-  /* else */
-  /*   layout = get_layout (cellbutton, widget, FALSE, 0); */
-
-  /* pango_layout_get_pixel_extents (layout, NULL, &rect); */
-  /* if (height) */
-  /*   *height = cell->ypad * 2 + rect.height; */
-
-  /* if (width) */
-  /*   *width = cell->xpad * 2 + rect.x + rect.width; */
-
-  /* if (cell_area) */
-  /* { */
-  /*   ol_logf (OL_DEBUG, "  cell_area:%dx%d\n", cell_area->width, cell_area->height); */
-  /*   if (x_offset) */
-  /*   { */
-  /*     if (gtk_widget_get_direction (widget) == GTK_TEXT_DIR_RTL) */
-  /*       *x_offset = (1.0 - cell->xalign) * (cell_area->width - (rect.x + rect.width + (2 * cell->xpad))); */
-  /*     else  */
-  /*       *x_offset = cell->xalign * (cell_area->width - (rect.x + rect.width + (2 * cell->xpad))); */
-
-  /*     *x_offset = MAX(*x_offset, 0); */
-  /*   } */
-  /*   if (y_offset) */
-  /*   { */
-  /*     *y_offset = cell->yalign * (cell_area->height - (rect.height + (2 * cell->ypad))); */
-  /*     *y_offset = MAX (*y_offset, 0); */
-  /*   } */
-  /* } */
-  /* else */
-  /* { */
-  /*   if (x_offset) *x_offset = 0; */
-  /*   if (y_offset) *y_offset = 0; */
-  /* } */
-
-  /* g_object_unref (layout); */
 }
 
 

--- a/src/ol_config_proxy.h
+++ b/src/ol_config_proxy.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef _OL_CONFIG_PROXY_H_
@@ -36,96 +36,93 @@
 #define OL_CONFIG_PROXY_GET_CLASS(obj)                                  \
   (G_TYPE_INSTANCE_GET_CLASS ((obj), OL_TYPE_CONFIG_PROXY, OlConfigProxyClass))
 
-typedef struct _OlConfigProxy OlConfigProxy;
-typedef struct _OlConfigProxyClass OlConfigProxyClass;
-
-struct _OlConfigProxy
-{
+typedef struct {
+  GObject object;
   GDBusProxy parent;
-};
+} OlConfigProxy;
 
-struct _OlConfigProxyClass
-{
+typedef struct {
+  GObjectClass gobject_class;
   GDBusProxyClass parent;
-};
+} OlConfigProxyClass;
 
 GType ol_config_proxy_get_type (void);
 
-/** 
+/**
  * @brief Gets the singleton instance of OlConfigProxy
- * 
- * 
+ *
+ *
  * @return An instance of OlConfigProxy, should not be freed
  */
 OlConfigProxy* ol_config_proxy_get_instance (void);
 
-/** 
+/**
  * @brief Sets an boolean property to the config
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
  *            indicates that it is a temporary config entry and should not be sync
  *            to the config file.
  * @param value The value of the property
- * 
+ *
  * @return If succeed, returns TRUE
  */
 gboolean ol_config_proxy_set_bool (OlConfigProxy *config,
                                    const gchar *key,
                                    gboolean value);
 
-/** 
+/**
  * @brief Sets an int property to the config
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
  *            indicates that it is a temporary config entry and should not be sync
  *            to the config file.
  * @param value The value of the property
- * 
+ *
  * @return If succeed, returns TRUE
  */
 gboolean ol_config_proxy_set_int (OlConfigProxy *config,
                                   const gchar *key,
                                   gint value);
 
-/** 
+/**
  * @brief Sets a double property to the config
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
  *            indicates that it is a temporary config entry and should not be sync
  *            to the config file.
  * @param value The value of the property
- * 
+ *
  * @return If succeed, returns TRUE
  */
 gboolean ol_config_proxy_set_double (OlConfigProxy *config,
                                      const gchar *key,
                                      gdouble value);
 
-/** 
+/**
  * @brief Sets a string property to the config
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
  *            indicates that it is a temporary config entry and should not be sync
  *            to the config file.
  * @param value The value of the property
- * 
+ *
  * @return If succeed, returns TRUE
  */
 gboolean ol_config_proxy_set_string (OlConfigProxy *config,
                                      const gchar *key,
                                      const gchar* value);
 
-/** 
+/**
  * @brief Sets a string list property to the config
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
@@ -134,7 +131,7 @@ gboolean ol_config_proxy_set_string (OlConfigProxy *config,
  * @param value The value of the property
  * @param len The length of the string property. -1 to indicate the list is
  *            terminated with NULL.
- * 
+ *
  * @return If succeed, returns TRUE
  */
 gboolean ol_config_proxy_set_str_list (OlConfigProxy *config,
@@ -142,9 +139,9 @@ gboolean ol_config_proxy_set_str_list (OlConfigProxy *config,
                                  const gchar * const *value,
                                  gint len);
 
-/** 
+/**
  * @brief Gets a boolean property from the config
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
@@ -152,16 +149,16 @@ gboolean ol_config_proxy_set_str_list (OlConfigProxy *config,
  *            to the config file.
  * @param default_value The default value to return if the config service is
  *                      unavaliable or the key is not found in the config.
- * 
+ *
  * @return If succeed, returns int value of the content. \
  *         If fail or the key does not exist, FALSE is returned.
  */
 gboolean ol_config_proxy_get_bool (OlConfigProxy *config,
                                    const gchar *key);
 
-/** 
+/**
  * @brief Gets a int property from the config
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
@@ -169,15 +166,15 @@ gboolean ol_config_proxy_get_bool (OlConfigProxy *config,
  *            to the config file.
  * @param default_value The default value to return if the config service is
  *                      unavaliable or the key is not found in the config.
- * 
+ *
  * @return If succeed, returns int value of the content. \
  *         If fail or the key does not exist, 0 is retuened.
  */
 gint ol_config_proxy_get_int (OlConfigProxy *config,
                               const gchar *key);
-/** 
+/**
  * @brief Gets a double property from the config
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
@@ -185,15 +182,15 @@ gint ol_config_proxy_get_int (OlConfigProxy *config,
  *            to the config file.
  * @param default_value The default value to return if the config service is
  *                      unavaliable or the key is not found in the config.
- * 
+ *
  * @return If succeed, returns double value of the content. \
  *         If fail or the key does not exist, 0.0 is returned.
  */
 gdouble ol_config_proxy_get_double (OlConfigProxy *config,
                                     const gchar *key);
-/** 
+/**
  * @brief Gets a string property of the config
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
@@ -201,23 +198,23 @@ gdouble ol_config_proxy_get_double (OlConfigProxy *config,
  *            to the config file.
  * @param default_value The default value to return if the config service is
  *                      unavaliable or the key is not found in the config.
- * 
+ *
  * @return If succeed, returns duplicated string value of the content, \
  *         must be freed by g_free. If fail or the key does not exist, returns NULL.
  */
 gchar* ol_config_proxy_get_string (OlConfigProxy *config,
                                    const gchar *key);
 
-/** 
+/**
  * @brief Gets a string property of the config
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
  *            indicates that it is a temporary config entry and should not be sync
  *            to the config file.
  * @param len return location of length of string list, or NULL
- * 
+ *
  * @return a NULL-terminated string array or NULL if the specified key cannot
  *         be found. The array should be freed with g_strfreev().
  *         If fail or the key does not exist, NULL will be returned.
@@ -226,87 +223,87 @@ gchar** ol_config_proxy_get_str_list (OlConfigProxy *config,
                                       const char *key,
                                       gsize *len);
 
-/** 
+/**
  * Sets the default value to a boolean config entry.
  * It is similar to ol_config_proxy_set_bool(). The difference is when a key
  * exists, the value will not be overwritten.
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
  *            indicates that it is a temporary config entry and should not be sync
  *            to the config file.
  * @param value The value of the property
- * 
+ *
  * @return If succeed, returns TRUE
  */
 gboolean ol_config_proxy_set_bool_default (OlConfigProxy *config,
                                            const gchar *key,
                                            gboolean value);
 
-/** 
+/**
  * Sets the default value to a integer config entry.
  *
  * It is similar to ol_config_proxy_set_int(). The difference is when a key exists,
  * the value will not be overwritten.
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
  *            indicates that it is a temporary config entry and should not be sync
  *            to the config file.
  * @param value The value of the property
- * 
+ *
  * @return If succeed, returns TRUE
  */
 gboolean ol_config_proxy_set_int_default (OlConfigProxy *config,
                                           const gchar *key,
                                           gint value);
 
-/** 
+/**
  * Sets the default value to a double config entry.
  *
  * It is similar to ol_config_proxy_set_double(). The difference is when a key
  * exists, the value will not be overwritten.
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
  *            indicates that it is a temporary config entry and should not be sync
  *            to the config file.
  * @param value The value of the property
- * 
+ *
  * @return If succeed, returns TRUE
  */
 gboolean ol_config_proxy_set_double_default (OlConfigProxy *config,
                                              const gchar *key,
                                              gdouble value);
 
-/** 
+/**
  * Sets the default value to a string config entry.
  *
  * It is similar to ol_config_proxy_set_string(). The difference is when a key
  * exists, the value will not be overwritten.
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
  *            indicates that it is a temporary config entry and should not be sync
  *            to the config file.
  * @param value The value of the property
- * 
+ *
  * @return If succeed, returns TRUE
  */
 gboolean ol_config_proxy_set_string_default (OlConfigProxy *config,
                                              const gchar *key,
                                              const gchar* value);
 
-/** 
+/**
  * Sets the default value to a string list config entry.
  *
  * It is similar to ol_config_proxy_set_string_list(). The difference is when a key
  * exists, the value will not be overwritten.
- * 
+ *
  * @param config An OlConfigProxy
  * @param key The key of the config value, should be in the form of "group/name", or
  *            any name started with a dot, like '.visible'. A key starting with a dot
@@ -315,20 +312,20 @@ gboolean ol_config_proxy_set_string_default (OlConfigProxy *config,
  * @param value The value of the property
  * @param len The length of the string property. -1 to indicate the list is
  *            terminated with NULL.
- * 
+ *
  * @return If succeed, returns TRUE
  */
 gboolean ol_config_proxy_set_str_list_default (OlConfigProxy *config,
                                                const gchar *key,
                                                const gchar * const *value,
                                                gint len);
-/** 
+/**
  * @brief Unload config module
- * 
+ *
  */
 void ol_config_proxy_unload (void);
 
-/** 
+/**
  * Sync the config settings immediately.
  *
  */

--- a/src/ol_config_proxy.h
+++ b/src/ol_config_proxy.h
@@ -36,15 +36,19 @@
 #define OL_CONFIG_PROXY_GET_CLASS(obj)                                  \
   (G_TYPE_INSTANCE_GET_CLASS ((obj), OL_TYPE_CONFIG_PROXY, OlConfigProxyClass))
 
-typedef struct {
-  GObject object;
-  GDBusProxy parent;
-} OlConfigProxy;
+typedef struct _OlConfigProxy OlConfigProxy;
+typedef struct _OlConfigProxyClass OlConfigProxyClass;
 
-typedef struct {
-  GObjectClass gobject_class;
+struct _OlConfigProxy
+{
+  GDBusProxy parent;
+  gpointer priv;
+};
+
+struct _OlConfigProxyClass
+{
   GDBusProxyClass parent;
-} OlConfigProxyClass;
+};
 
 GType ol_config_proxy_get_type (void);
 

--- a/src/ol_image_button.c
+++ b/src/ol_image_button.c
@@ -14,7 +14,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "ol_image_button.h"
 #include "ol_debug.h"
@@ -27,10 +27,9 @@ enum ImageIndex {
   STATE_DISABLED,
   SLICE_NUM,
 };
-#define OL_IMAGE_BUTTON_GET_PRIVATE(obj)   (G_TYPE_INSTANCE_GET_PRIVATE \
-                                            ((obj),                     \
-                                             ol_image_button_get_type (),  \
-                                             OlImageButtonPriv))
+#define OL_IMAGE_BUTTON_GET_PRIVATE(obj) \
+    ((OlImageButtonPriv *)((OL_IMAGE_BUTTON(obj))->priv))
+
 typedef struct _OlImageButtonPriv OlImageButtonPriv;
 struct _OlImageButtonPriv
 {
@@ -118,7 +117,7 @@ ol_image_button_expose (GtkWidget *widget,
     cairo_rectangle (cr, x, y,
                      sw, sh);
     cairo_clip (cr);
-    
+
     int img_index = STATE_NORMAL;
     GtkStateType state = GTK_WIDGET_STATE (widget);
     if (state == GTK_STATE_ACTIVE)
@@ -153,8 +152,32 @@ ol_image_button_class_init (OlImageButtonClass *klass)
 static void
 ol_image_button_init (OlImageButton *btn)
 {
-  OlImageButtonPriv *priv = OL_IMAGE_BUTTON_GET_PRIVATE (btn);
-  priv->image = NULL;
+  /* Allocate Private data structure */
+  (OL_IMAGE_BUTTON(btn))->priv = \
+      (OlImageButtonPriv *) g_malloc0(sizeof(OlImageButtonPriv));
+  /* If correctly allocated, initialize parameters */
+  if((OL_IMAGE_BUTTON(btn))->priv != NULL)
+  {
+    OlImageButtonPriv *priv = OL_IMAGE_BUTTON_GET_PRIVATE (btn);
+    priv->image = NULL;
+  }
+}
+
+static void
+ol_image_button_dispose(GObject *object)
+{
+    OlImageButton *self = (OlImageButton *)object;
+    OlImageButtonPriv *priv = OL_IMAGE_BUTTON_GET_PRIVATE(self);
+    /* Check if not NULL! To avoid calling dispose multiple times */
+    if(priv != NULL)
+    {
+        /* Deallocate contents of the private data, if any */
+        /* Deallocate private data structure */
+        g_free(priv);
+        /* And finally set the opaque pointer back to NULL, so that
+         *  we don't deallocate it twice. */
+        (OL_IMAGE_BUTTON(self))->priv = NULL;
+    }
 }
 
 static void

--- a/src/ol_image_button.h
+++ b/src/ol_image_button.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_IMAGE_BUTTON_H_
 #define _OL_IMAGE_BUTTON_H_
@@ -33,6 +33,7 @@ typedef struct _OlImageButtonClass OlImageButtonClass;
 struct _OlImageButton
 {
   GtkButton button;
+  gpointer priv; /** Private data pointer */
 };
 
 struct _OlImageButtonClass
@@ -42,23 +43,23 @@ struct _OlImageButtonClass
 
 GtkType ol_image_button_get_type (void);
 
-/** 
+/**
  * @brief Create a new image button
- * 
- * 
+ *
+ *
  * @return A new instance of image button
  */
 GtkWidget *ol_image_button_new (void);
 
-/** 
+/**
  * @brief Sets the image of the button
  *
  * The image should contains 4 frames: normal, hover, pressed, disabled, from
  * left to right. The width of each frame must be equal.
- * 
- * @param btn 
+ *
+ * @param btn
  * @param image The image of the button
  */
-void ol_image_button_set_pixbuf (OlImageButton *btn, GdkPixbuf *image); 
+void ol_image_button_set_pixbuf (OlImageButton *btn, GdkPixbuf *image);
 
 #endif /* _OL_IMAGE_BUTTON_H_ */

--- a/src/ol_lrc.h
+++ b/src/ol_lrc.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_LRC_H_
 #define _OL_LRC_H_
@@ -40,6 +40,7 @@ typedef struct _OlLrc OlLrc;
 struct _OlLrc
 {
   GObject parent;
+  gpointer priv; /** Private data pointer */
 };
 
 typedef struct _OlLrcClass OlLrcClass;
@@ -52,7 +53,7 @@ struct _OlLrcClass
 
 GType ol_lrc_get_type (void);
 
-/** 
+/**
  * @brief An iterator to iterate the content of the LRC file
  *
  * The iterator points to a line of the content. From the iterator you can get the
@@ -63,16 +64,16 @@ GType ol_lrc_get_type (void);
 typedef struct _OlLrcIter OlLrcIter;
 struct _OlLrcIter;
 
-/** 
+/**
  * @brief Create a new OlLrc instance
- * 
+ *
  * @return The OlLrc instance of the file, or NULL if filename doesn't exist.
  *         You should free it with g_object_unref.
  */
 OlLrc *ol_lrc_new (OlLyrics *lyric_proxy,
                    const gchar *uri);
 
-/** 
+/**
  * Sets the LRC attributes from GVariant
  *
  * This function is intented for D-Bus communication. The returned attributes of
@@ -81,47 +82,47 @@ OlLrc *ol_lrc_new (OlLyrics *lyric_proxy,
  *
  * The GVariant contains a dictionary with strings as keys and strings as values.
  *
- * @param lrc 
+ * @param lrc
  * @param attribute GVariant of type a{ss}
  */
 void ol_lrc_set_attributes_from_variant (OlLrc *lrc,
                                          GVariant *attribute);
 
-/** 
+/**
  * Sets the LRC content from GVariant
  *
  * This function is intented for D-Bus communication. The returned content of
  * GetLyrics or GetCurrentLyrics call should be able to pass as the content
  * parameter directly.
- * 
+ *
  * The GVariant contains an array of a dictionary with strings as keys and
  * variants as values.
  *
  * It is guaranteed that there is at least one line in lrc after setting the
  * content
  *
- * @param lrc 
+ * @param lrc
  * @param content GVariant of type a{ss}
  */
 void ol_lrc_set_content_from_variant (OlLrc *lrc,
                                       GVariant *content);
 
-/** 
+/**
  * Gets the value of an attribute of an LRC file
- * 
- * @param lrc 
- * @param key 
- * 
+ *
+ * @param lrc
+ * @param key
+ *
  * @return NULL if the attribute doesn't exist. Otherwise return the value
  *         of the key.
  */
 const char *ol_lrc_get_attribute (OlLrc *lrc,
                                   const char *key);
-/** 
+/**
  * @brief Get the number of lyric items
- * 
- * @param lrc 
- * 
+ *
+ * @param lrc
+ *
  * @return The number of lyric items
  */
 guint ol_lrc_get_item_count (OlLrc *lrc);
@@ -135,12 +136,12 @@ guint ol_lrc_get_item_count (OlLrc *lrc);
  * sync the offset change 1 second after last ol_lrc_set_offset() call.
  *
  * @param lrc
- * @param offset The offset of which should be ajusted 
+ * @param offset The offset of which should be ajusted
  */
 void ol_lrc_set_offset (OlLrc *lrc,
                         int offset);
 
-/** 
+/**
  * Get the offset of the LRC file
  *
  * @param lrc
@@ -149,55 +150,55 @@ void ol_lrc_set_offset (OlLrc *lrc,
  */
 int ol_lrc_get_offset (OlLrc *lrc);
 
-/** 
+/**
  * Sets the duration of the track.
  *
  * The duration is used to calculate the duration and percentage of the last
  * line of lyrics. If the duration is less than the start time of the last line,
  * it is invalid and will not be used.
- * 
- * @param lrc 
- * @param duration 
+ *
+ * @param lrc
+ * @param duration
  */
 void ol_lrc_set_duration (OlLrc *lrc, guint64 duration);
 
-/** 
+/**
  * Gets the duration of the track.
- * 
- * @param lrc 
- * 
+ *
+ * @param lrc
+ *
  * @return The duration of the track.
  */
 guint64 ol_lrc_get_duration (OlLrc *lrc);
-/** 
+/**
  * @brief Get the URI of the LRC file
- * 
- * @param lrc 
- * 
+ *
+ * @param lrc
+ *
  * @return The URI or NULL. The lrc owns the the uri, so don't modify or free it.
  */
 const char *ol_lrc_get_uri (OlLrc *lrc);
 
 
-/** 
+/**
  * Frees an iterator.
- * 
- * @param iter 
+ *
+ * @param iter
  */
 void ol_lrc_iter_free (OlLrcIter *iter);
 
-/** 
+/**
  * @brief Gets an iterator by the ID of the line
- * 
- * @param lrc 
- * @param id 
- * 
+ *
+ * @param lrc
+ * @param id
+ *
  * @return The lyric iterator with the id, or NULL if not found. Should be freed
  *         with ol_lrc_iter_free
  */
 OlLrcIter *ol_lrc_iter_from_id (OlLrc *lrc, guint id);
 
-/** 
+/**
  * @brief Gets the lyric iterator that fits the given timestamp
  *
  * The returned lyric's start time should be less or equal than the given time,
@@ -210,43 +211,43 @@ OlLrcIter *ol_lrc_iter_from_id (OlLrc *lrc, guint id);
  * This function returns the upperbound, which means that if there are more than
  * one line starts with the given timestamp, this function return returns the last
  * on.
- * 
+ *
  * @param lrc The LRC file
  * @param timestamp The timestamp
- * 
+ *
  * @return The iterator of the timestamp. Should be freed with ol_lrc_iter_free
  */
 OlLrcIter *ol_lrc_iter_from_timestamp (OlLrc *lrc,
                                        gint64 timestamp);
-/** 
+/**
  * @brief Move to the previous line of lyrics
  *
  * @param iter
- * 
+ *
  * @return FALSE if the given iter is the first one. TRUE if succeed.
  */
 gboolean ol_lrc_iter_prev (OlLrcIter *iter);
 
-/** 
+/**
  * @brief Move to the next line of lyrics
  *
- * @param iter The iterator 
- * 
+ * @param iter The iterator
+ *
  * @return FALSE if the given iter is the last one. TRUE if succeed.
  */
 gboolean ol_lrc_iter_next (OlLrcIter *iter);
 
-/** 
+/**
  * Move the iterator to the line of the given ID
- * 
- * @param iter 
- * @param id 
- * 
+ *
+ * @param iter
+ * @param id
+ *
  * @return TRUE if success, or FALSE if the id is out of range.
  */
 gboolean ol_lrc_iter_move_to (OlLrcIter *iter, guint id);
 
-/** 
+/**
  * Get the information of the line represented by the iterator and move the
  * iterator to the next.
  *
@@ -256,13 +257,13 @@ gboolean ol_lrc_iter_move_to (OlLrcIter *iter, guint id);
  * {
  *   do_someting ();
  * }
- * 
- * @param iter 
+ *
+ * @param iter
  * @param id The return location of id of the current iterator. NULL is OK.
  * @param timestamp The return location of id of the current timestamp. NULL is OK.
  * @param text The return location of id of the current lyric text. NULL is OK.
  *             Should NOT be modified or freed.
- * 
+ *
  * @return FALSE if the iterator reaches the end of the lyrics. Otherwise TRUE will
  *         be returned and the id, timestamp and text will be set.
  */
@@ -271,49 +272,49 @@ gboolean ol_lrc_iter_loop (OlLrcIter *iter,
                            gint64 *timestamp,
                            const char **text);
 
-/** 
+/**
  * Get the ID of the line.
  *
  * The ID is the index of the lyric line.
- * @param iter 
- * 
- * @return 
+ * @param iter
+ *
+ * @return
  */
 guint ol_lrc_iter_get_id (OlLrcIter *iter);
 
-/** 
+/**
  * @brief Get the timestamp of the line, in milliseconds
  *
  * The time is calculated with offset of LRC
- * 
+ *
  * @param iter The iterator
- * 
+ *
  * @return The timestamp of the line represented by the iterator.
  */
 gint64 ol_lrc_iter_get_timestamp (OlLrcIter *iter);
 
-/** 
+/**
  * @brief Get the text of the line
- * 
- * @param item 
- * 
+ *
+ * @param item
+ *
  * @return The text of the lyric item.
  */
 const char *ol_lrc_iter_get_text(OlLrcIter *iter);
 
-/** 
+/**
  * @brief Get the id of the line
  *
  * The id differs with different lyric item, and is in ascending order by
  * timestamp. Ids start from 0.
- * 
- * @param item 
- * 
+ *
+ * @param item
+ *
  * @return The id of the item, or 0 if the item is invalid.
  */
 guint ol_lrc_iter_get_id (OlLrcIter *iter);
 
-/** 
+/**
  * Gets the duration of the line
  *
  * The duration of the line is the difference between the timestamp of this and the
@@ -322,33 +323,33 @@ guint ol_lrc_iter_get_id (OlLrcIter *iter);
  * If the line is the last one, the duration is the duration of the track minus the
  * timestamp of the line. If the duration is less than the timestamp of the last
  * line, the duration of the last line will be 5 seconds.
- * 
- * @param iter 
- * 
+ *
+ * @param iter
+ *
  * @return The duration of the line. Note that this may be 0.
  */
 guint64 ol_lrc_iter_get_duration (OlLrcIter *iter);
 
-/** 
+/**
  * Figure out how much of an single lyric text has been played when the position
  * of the track reaches given value.
  *
  * The returned value is guaranteed in the range of [0.0, 1.0].
- * 
- * @param iter 
+ *
+ * @param iter
  * @param time_ms The position of the track, in milliseconds.
- * 
- * @return 
+ *
+ * @return
  */
 gdouble ol_lrc_iter_compute_percentage (OlLrcIter *iter,
                                         gint64 time_ms);
 
-/** 
+/**
  * Determine if a iterator is out of range.
- * 
- * @param iter 
- * 
- * @return 
+ *
+ * @param iter
+ *
+ * @return
  */
 gboolean ol_lrc_iter_is_valid (OlLrcIter *iter);
 

--- a/src/ol_lyric_source.c
+++ b/src/ol_lyric_source.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2012  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <string.h>
@@ -37,21 +37,14 @@ G_DEFINE_TYPE (OlLyricSourceCandidate,
                ol_lyric_source_candidate,
                G_TYPE_OBJECT);
 
-#define OL_LYRIC_SOURCE_GET_PRIVATE(obj)                                \
-  (G_TYPE_INSTANCE_GET_PRIVATE                                          \
-   ((obj),                                                              \
-    OL_TYPE_LYRIC_SOURCE,                                               \
-    OlLyricSourcePrivate))
-#define OL_LYRIC_SOURCE_CANDIDATE_GET_PRIVATE(obj)                      \
-  (G_TYPE_INSTANCE_GET_PRIVATE                                          \
-   ((obj),                                                              \
-    OL_TYPE_LYRIC_SOURCE_CANDIDATE,                                     \
-    OlLyricSourceCandidatePrivate))
-#define OL_LYRIC_SOURCE_TASK_GET_PRIVATE(obj)                           \
-  (G_TYPE_INSTANCE_GET_PRIVATE                                          \
-   ((obj),                                                              \
-    OL_TYPE_LYRIC_SOURCE_TASK,                                          \
-    OlLyricSourceTaskPrivate))
+#define OL_LYRIC_SOURCE_GET_PRIVATE(obj) \
+  ((OlLyricSourcePrivate *)((OL_LYRIC_SOURCE(obj))->priv))
+
+#define OL_LYRIC_SOURCE_CANDIDATE_GET_PRIVATE(obj) \
+  ((OlLyricSourceCandidatePrivate *)((OL_LYRIC_SOURCE_CANDIDATE(obj))->priv))
+
+#define OL_LYRIC_SOURCE_TASK_GET_PRIVATE(obj) \
+  ((OlLyricSourceTaskPrivate *)((OL_LYRIC_SOURCE_TASK(obj))->priv))
 
 struct _OlLyricSourceInfo
 {
@@ -199,15 +192,39 @@ ol_lyric_source_class_init (OlLyricSourceClass *klass)
 static void
 ol_lyric_source_init (OlLyricSource *source)
 {
-  OlLyricSourcePrivate *priv = OL_LYRIC_SOURCE_GET_PRIVATE (source);
-  priv->search_tasks = g_hash_table_new_full (g_direct_hash,
-                                              g_direct_equal,
-                                              NULL,
-                                              (GDestroyNotify)g_object_unref);
-  priv->download_tasks = g_hash_table_new_full (g_direct_hash,
+  /* Allocate Private data structure */
+  (OL_LYRIC_SOURCE(source))->priv = \
+  (OlLyricSourcePrivate *) g_malloc0(sizeof(OlLyricSourcePrivate));
+  /* If correctly allocated, initialize parameters */
+  if((OL_LYRIC_SOURCE(source))->priv != NULL)
+  {
+    OlLyricSourcePrivate *priv = OL_LYRIC_SOURCE_GET_PRIVATE (source);
+    priv->search_tasks = g_hash_table_new_full (g_direct_hash,
                                                 g_direct_equal,
                                                 NULL,
                                                 (GDestroyNotify)g_object_unref);
+    priv->download_tasks = g_hash_table_new_full (g_direct_hash,
+                                                  g_direct_equal,
+                                                  NULL,
+                                                  (GDestroyNotify)g_object_unref);
+  }
+}
+
+static void
+ol_lyric_source_dispose(GObject *object)
+{
+  OlLyricSource *self = (OlLyricSource *)object;
+  OlLyricSourcePrivate *priv = OL_LYRIC_SOURCE_GET_PRIVATE(self);
+  /* Check if not NULL! To avoid calling dispose multiple times */
+  if(priv != NULL)
+  {
+    /* Deallocate contents of the private data, if any */
+    /* Deallocate private data structure */
+    g_free(priv);
+    /* And finally set the opaque pointer back to NULL, so that
+     *  we don't deallocate it twice. */
+    (OL_LYRIC_SOURCE(self))->priv = NULL;
+  }
 }
 
 OlLyricSource *
@@ -537,7 +554,7 @@ ol_lyric_source_search_default (OlLyricSource *source,
   ol_metadata_set_artist (search_metadata,
                           ol_metadata_get_search_artist(metadata));
   ol_metadata_set_title (search_metadata,
-                         ol_metadata_get_search_title(metadata));  
+                         ol_metadata_get_search_title(metadata));
   task = ol_lyric_source_search (source, search_metadata, source_ids);
 
   // comment out original call
@@ -545,7 +562,7 @@ ol_lyric_source_search_default (OlLyricSource *source,
 
   // free created metadata
   ol_metadata_free (search_metadata);
- 
+
   for (; source_ids; source_ids = g_list_delete_link (source_ids, source_ids))
   {
     g_free (source_ids->data);

--- a/src/ol_lyric_source.c
+++ b/src/ol_lyric_source.c
@@ -711,6 +711,32 @@ ol_lyric_source_candidate_class_init (OlLyricSourceCandidateClass *klass)
 static void
 ol_lyric_source_candidate_init (OlLyricSourceCandidate *source)
 {
+  /* Allocate Private data structure */
+  (OL_LYRIC_SOURCE_CANDIDATE(source))->priv = \
+    (OlLyricSourceCandidatePrivate *) g_malloc0(sizeof(OlLyricSourceCandidatePrivate));
+  /* If correctly allocated, initialize parameters */
+  if((OL_LYRIC_SOURCE_CANDIDATE(source))->priv != NULL)
+  {
+    OlLyricSourceCandidatePrivate *priv = OL_LYRIC_SOURCE_CANDIDATE_GET_PRIVATE(source);
+    /* Initialize private data, if any */
+  }
+}
+
+static void
+ol_lyric_source_candidate_dispose(GObject *object)
+{
+  OlLyricSourceCandidate *self = (OlLyricSourceCandidate *)object;
+  OlLyricSourceCandidatePrivate *priv = OL_LYRIC_SOURCE_CANDIDATE_GET_PRIVATE(self);
+  /* Check if not NULL! To avoid calling dispose multiple times */
+  if(priv != NULL)
+  {
+    /* Deallocate contents of the private data, if any */
+    /* Deallocate private data structure */
+    g_free(priv);
+    /* And finally set the opaque pointer back to NULL, so that
+     *  we don't deallocate it twice. */
+    (OL_LYRIC_SOURCE_CANDIDATE(self))->priv = NULL;
+  }
 }
 
 static OlLyricSourceCandidate *
@@ -967,6 +993,31 @@ ol_lyric_source_task_class_init (OlLyricSourceTaskClass *klass)
 static void
 ol_lyric_source_task_init (OlLyricSourceTask *task)
 {
+  /* Allocate Private data structure */
+  (OL_LYRIC_SOURCE_TASK(task))->priv = \
+    (OlLyricSourceTaskPrivate *) g_malloc0(sizeof(OlLyricSourceTaskPrivate));
+  /* If correctly allocated, initialize parameters */
+  if((OL_LYRIC_SOURCE_TASK(task))->priv != NULL)
+  {
+    OlLyricSourceTaskPrivate *priv = OL_LYRIC_SOURCE_TASK_GET_PRIVATE(task);
+  }
+}
+
+static void
+ol_lyric_source_task_dispose(GObject *object)
+{
+  OlLyricSourceTask *self = (OlLyricSourceTask *)object;
+  OlLyricSourceTaskPrivate *priv = OL_LYRIC_SOURCE_TASK_GET_PRIVATE(self);
+  /* Check if not NULL! To avoid calling dispose multiple times */
+  if(priv != NULL)
+  {
+    /* Deallocate contents of the private data, if any */
+    /* Deallocate private data structure */
+    g_free(priv);
+    /* And finally set the opaque pointer back to NULL, so that
+     *  we don't deallocate it twice. */
+    (OL_LYRIC_SOURCE_TASK(self))->priv = NULL;
+  }
 }
 
 static void

--- a/src/ol_lyric_source.h
+++ b/src/ol_lyric_source.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2012  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef _OL_LYRIC_SOURCE_H_
@@ -158,14 +158,14 @@ typedef struct _OlLyricSourceCandidateClass OlLyricSourceCandidateClass;
 typedef struct _OlLyricSourceInfo OlLyricSourceInfo;
 struct _OlLyricSourceInfo;
 
-/** 
+/**
  * Prototype of callback function of 'complete' signal in
  * OlLyricSourceSearchTask.
- * 
+ *
  * @param task The task object that emits this signal.
  * @param status The status of the search task.
  * @param results A list of OlLyricSourceCandidate* objects.
- * @param userdata 
+ * @param userdata
  */
 typedef void (*OlSearchCompleteFunc) (OlLyricSourceSearchTask *task,
                                       enum OlLyricSourceStatus status,
@@ -176,16 +176,16 @@ typedef void (*OlSearchStartedFunc) (OlLyricSourceSearchTask *task,
                                      const gchar *sourcename,
                                      gpointer userdata);
 
-/** 
+/**
  * Prototype of callback function of 'complete' signal in
  * OlLyricSourceDownloadTask.
- * 
+ *
  * @param task The task that emits this signal.
  * @param status The status of the download task.
  * @param content If status is OL_LYRIC_SOURCE_STATUS_SUCCESS, this
  *        value is the content of the downloaded lyric file.
  * @param len The length of the content.
- * @param userdata 
+ * @param userdata
  */
 typedef void (*OlDownloadCompleteFunc) (OlLyricSourceDownloadTask *task,
                                         enum OlLyricSourceStatus status,
@@ -196,6 +196,7 @@ typedef void (*OlDownloadCompleteFunc) (OlLyricSourceDownloadTask *task,
 struct _OlLyricSourceTask
 {
   GObject parent;
+  gpointer priv;
 };
 
 struct _OlLyricSourceTaskClass
@@ -227,16 +228,19 @@ struct _OlLyricSourceDownloadTaskClass
 struct _OlLyricSource
 {
   GDBusProxy parent;
+  gpointer priv;
 };
 
 struct _OlLyricSourceClass
 {
   GDBusProxyClass parent_class;
+  gpointer priv;
 };
 
 struct _OlLyricSourceCandidate
 {
   GObject parent;
+  gpointer priv;
 };
 
 struct _OlLyricSourceCandidateClass
@@ -245,28 +249,28 @@ struct _OlLyricSourceCandidateClass
 };
 
 /* OlLyricSource */
-/** 
+/**
  * Creates a new lyric source proxy
- * 
+ *
  */
 OlLyricSource *ol_lyric_source_new (void);
 GType ol_lyric_source_get_type (void);
 /**
  * Lists all the available sources.
- * 
+ *
  * @param source The lyric source proxy.
- * 
+ *
  * @return A list of `OlLyricSourceInfo*`. Caller should free this list and its
  * elements.
  */
 GList *ol_lyric_source_list_sources (OlLyricSource* source);
 /**
  * Search lyrics for a given metadata.
- * 
+ *
  * @param source The lyric source proxy.
  * @param metadata The metadata to be searched for.
  * @param source_ids A list of gchar *. The ID of lyric sources.
- * 
+ *
  * @return An OlLyricSourceSearchTask object of the search task. The
  * lyric source proxy owns a reference of it. If you want to take a
  * reference to the returned object, use g_object_ref().
@@ -276,10 +280,10 @@ OlLyricSourceSearchTask *ol_lyric_source_search (OlLyricSource *source,
                                                  GList *source_ids);
 /**
  * Search for lyrics with default lyric sources.
- * 
+ *
  * @param source The lyric source proxy.
  * @param metadata The metadata to be searched for.
- * 
+ *
  * @return An OlLyricSourceSearchTask object of the search task. The
  * lyric source proxy owns a reference of it. If you want to take a
  * reference to the returned object, use g_object_ref().
@@ -288,10 +292,10 @@ OlLyricSourceSearchTask *ol_lyric_source_search_default (OlLyricSource *source,
                                                          OlMetadata *metadata);
 /**
  * Download a lyric file provided by a candidate.
- * 
+ *
  * @param source The lyric source proxy.
  * @param candidate The candidate.
- * 
+ *
  * @return An OlLyricSourceDownloadTask object of the search task. If
  * you want to take a reference to the returned object, use
  * g_object_ref().

--- a/src/ol_lyrics.c
+++ b/src/ol_lyrics.c
@@ -16,8 +16,8 @@ enum {
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
-#define OL_LYRICS_GET_PRIVATE(object)                                 \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((object), OL_TYPE_LYRICS, OlLyricsPrivate))
+#define OL_LYRICS_GET_PRIVATE(object) \
+    ((OlLyricsPrivate *)((OL_LYRICS(object))->priv))
 
 static void ol_lyrics_finalize (GObject *object);
 static void ol_lyrics_g_signal (GDBusProxy *proxy,

--- a/src/ol_lyrics.h
+++ b/src/ol_lyrics.h
@@ -42,6 +42,7 @@ typedef struct _OlLyrics OlLyrics;
 struct _OlLyrics
 {
   GDBusProxy parent;
+  gpointer priv;
 };
 
 typedef struct _OlLyricsClass OlLyricsClass;
@@ -68,9 +69,9 @@ OlLyrics *ol_lyrics_proxy_new_finish (GAsyncResult *res,
 
 /**
  * Gets the lyrics of current playing track
- * 
- * @param proxy 
- * 
+ *
+ * @param proxy
+ *
  * @return NULL if no lyrics found. Otherwise return an #OlLrc object
  *         representing the lyrics. You should use g_object_unref() to free
  *         the returned #OlLrc object.
@@ -79,10 +80,10 @@ OlLrc *ol_lyrics_get_current_lyrics (OlLyrics *proxy);
 
 /**
  * Gets the lyrics assigned to the given metadata
- * 
- * @param proxy 
+ *
+ * @param proxy
  * @param metadata The metadata, must not be #NULL
- * 
+ *
  * @return NULL if no lyrics found. Otherwise return an #OlLrc object
  *         representing the lyrics. You should use g_object_unref() to free
  *         the returned #OlLrc object.
@@ -93,14 +94,14 @@ OlLrc *ol_lyrics_get_lyrics (OlLyrics *proxy,
 /**
  * Gets the content of the LRC file assigned to the specified metadata in
  * plain text.
- * 
- * @param proxy 
+ *
+ * @param proxy
  * @param metadata The metadata, must not be #NULL.
  * @param uri The return location of the uri of the LRC file. Should be freed with
  *        g_free(). Can be #NULL.
  * @param content The return location of the content of the LRC file. Should be
  *        freed with g_free(). Can be #NULL.
- * 
+ *
  * @return #TRUE if there are LRC file assigned to #metadata. If #metadata is
  *         assigned to not show any lyrics, #TRUE will be returned and #content will
  *         pointed to an empty string rather than #NULL.
@@ -113,13 +114,13 @@ gboolean ol_lyrics_get_raw_lyrics (OlLyrics *proxy,
 /**
  * Gets the content of the LRC file assigned to the current track in
  * plain text.
- * 
- * @param proxy 
+ *
+ * @param proxy
  * @param uri The return location of the uri of the LRC file. Should be freed with
  *        g_free(). Can be #NULL.
  * @param content The return location of the content of the LRC file. Should be
  *        freed with g_free(). Can be #NULL.
- * 
+ *
  * @return #TRUE if there are LRC file assigned to #metadata. If #metadata is
  *         assigned to not show any lyrics, #TRUE will be returned and #content will
  *         pointed to an empty string rather than #NULL.
@@ -130,12 +131,12 @@ gboolean ol_lyrics_get_current_raw_lyrics (OlLyrics *proxy,
 
 /**
  * Sets the content of LRC file for given metadata.
- * 
- * @param proxy 
+ *
+ * @param proxy
  * @param metadata The metadata, must not be #NULL.
  * @param content The content of the LRC file, must not be #NULL
  * @param error
- * 
+ *
  * @return If succeed, the URI of the new LRC file of the content will be returned.
  *         If failed, #NULL will be returned and the error will be set. The returned
  *         URI should be freed with g_free().
@@ -150,11 +151,11 @@ gchar *ol_lyrics_set_content (OlLyrics *proxy,
  *
  * The URI should be valid URI format defined in the D-Bus specification of the
  * daemon
- * @param proxy 
+ * @param proxy
  * @param metadata The metadata to be assigned. Must not be #NULL.
  * @param uri The URI of the LRC file. Must not be #NULL.
- * @param error 
- * 
+ * @param error
+ *
  * @return If success, return #TRUE. Otherwise return #FALSE and #error will be
  *         set.
  */
@@ -165,11 +166,11 @@ gboolean ol_lyrics_assign (OlLyrics *proxy,
 
 /**
  * Sets the offset of a given LRC file.
- * 
- * @param proxy 
+ *
+ * @param proxy
  * @param uri The URI of the LRC file. Must not be #NULL.
  * @param offset The offset.
- * 
+ *
  * @return #TRUE if success. Otherwise return #FALSE and #error will be
  *         set.
  */

--- a/src/ol_osd_toolbar.c
+++ b/src/ol_osd_toolbar.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldi@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,17 +15,16 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "ol_osd_toolbar.h"
 #include "ol_image_button.h"
 #include "ol_stock.h"
 #include "ol_debug.h"
 
-#define OL_OSD_TOOLBAR_GET_PRIVATE(obj)   (G_TYPE_INSTANCE_GET_PRIVATE \
-                                            ((obj),                     \
-                                             ol_osd_toolbar_get_type (),  \
-                                             OlOsdToolbarPriv))
+#define OL_OSD_TOOLBAR_GET_PRIVATE(obj) \
+    ((OlOsdToolbarPriv *)((OL_OSD_TOOLBAR(obj))->priv))
+
 typedef struct _OlOsdToolbarPriv OlOsdToolbarPriv;
 struct _OlOsdToolbarPriv
 {
@@ -147,7 +146,7 @@ _add_button (OlOsdToolbar *toolbar,
                                                   btn_spec->stock,
                                                   16,
                                                   0);
-  
+
   GdkPixbuf *image = gdk_pixbuf_new_from_file (gtk_icon_info_get_filename (info),
                                                NULL);
   gtk_icon_info_free (info);
@@ -238,20 +237,44 @@ ol_osd_toolbar_class_init (OlOsdToolbarClass *klass)
 static void
 ol_osd_toolbar_init (OlOsdToolbar *toolbar)
 {
-  OlOsdToolbarPriv *priv = OL_OSD_TOOLBAR_GET_PRIVATE (toolbar);
-  gtk_alignment_set (GTK_ALIGNMENT (toolbar), 0.5, 0.5, 0.0, 0.0);
-  toolbar->center_box = GTK_HBOX (gtk_hbox_new (FALSE, 0));
-  gtk_container_add (GTK_CONTAINER (toolbar), GTK_WIDGET (toolbar->center_box));
-  
-  toolbar->prev_button = _add_button (toolbar, &btn_spec[BTN_PREV]);
-  toolbar->play_button = _add_button (toolbar, &btn_spec[BTN_PLAY]);
-  toolbar->pause_button = _add_button (toolbar, &btn_spec[BTN_PAUSE]);
-  toolbar->stop_button = _add_button (toolbar, &btn_spec[BTN_STOP]);
-  toolbar->next_button = _add_button (toolbar, &btn_spec[BTN_NEXT]);
+  /* Allocate Private data structure */
+  (OL_OSD_TOOLBAR(toolbar))->priv = \
+     (OlOsdToolbarPriv *) g_malloc0(sizeof(OlOsdToolbarPriv));
+  /* If correctly allocated, initialize parameters */
+  if((OL_OSD_TOOLBAR(toolbar))->priv != NULL)
+  {
+    OlOsdToolbarPriv *priv = OL_OSD_TOOLBAR_GET_PRIVATE (toolbar);
+    gtk_alignment_set (GTK_ALIGNMENT (toolbar), 0.5, 0.5, 0.0, 0.0);
+    toolbar->center_box = GTK_HBOX (gtk_hbox_new (FALSE, 0));
+    gtk_container_add (GTK_CONTAINER (toolbar), GTK_WIDGET (toolbar->center_box));
 
-  priv->player = NULL;
-  _update_status (toolbar);
-  _update_caps (toolbar);
+    toolbar->prev_button = _add_button (toolbar, &btn_spec[BTN_PREV]);
+    toolbar->play_button = _add_button (toolbar, &btn_spec[BTN_PLAY]);
+    toolbar->pause_button = _add_button (toolbar, &btn_spec[BTN_PAUSE]);
+    toolbar->stop_button = _add_button (toolbar, &btn_spec[BTN_STOP]);
+    toolbar->next_button = _add_button (toolbar, &btn_spec[BTN_NEXT]);
+
+    priv->player = NULL;
+    _update_status (toolbar);
+    _update_caps (toolbar);
+  }
+}
+
+static void
+my_gobject_dispose(GObject *object)
+{
+    OlOsdToolbar *toolbar = (OlOsdToolbar *)object;
+    OlOsdToolbarPriv *priv = OL_OSD_TOOLBAR_GET_PRIVATE (toolbar);
+    /* Check if not NULL! To avoid calling dispose multiple times */
+    if(priv != NULL)
+    {
+        /* Deallocate contents of the private data, if any */
+        /* Deallocate private data structure */
+        g_free(priv);
+        /* And finally set the opaque pointer back to NULL, so that
+         *  we don't deallocate it twice. */
+        (OL_OSD_TOOLBAR(toolbar))->priv = NULL;
+    }
 }
 
 static void

--- a/src/ol_osd_toolbar.h
+++ b/src/ol_osd_toolbar.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_OSD_TOOLBAR_H_
 #define _OL_OSD_TOOLBAR_H_
@@ -40,6 +40,7 @@ struct _OlOsdToolbar
   GtkButton *prev_button;
   GtkButton *next_button;
   GtkButton *stop_button;
+  gpointer priv; /** Private data pointer */
 };
 
 struct _OlOsdToolbarClass

--- a/src/ol_osd_window.c
+++ b/src/ol_osd_window.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldi@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <string.h>
 #include <math.h>
@@ -23,10 +23,8 @@
 #include "ol_utils.h"
 #include "ol_debug.h"
 
-#define OL_OSD_WINDOW_GET_PRIVATE(obj)   (G_TYPE_INSTANCE_GET_PRIVATE  \
-                                          ((obj),                      \
-                                           ol_osd_window_get_type (),  \
-                                           OlOsdWindowPrivate))
+#define OL_OSD_WINDOW_GET_PRIVATE(obj)  \
+    ((OlOsdWindowPrivate *)((OL_OSD_WINDOW(obj))->priv))
 
 enum {
   PROP_0,
@@ -273,7 +271,7 @@ ol_osd_window_paint_bg (OlOsdWindow *osd, cairo_t *cr)
                    sw - BORDER_WIDTH * 2, sh - BORDER_WIDTH * 2,
                    BORDER_WIDTH, BORDER_WIDTH,
                    w - BORDER_WIDTH * 2, h - BORDER_WIDTH * 2);
-    
+
     }
     else
     {
@@ -282,7 +280,7 @@ ol_osd_window_paint_bg (OlOsdWindow *osd, cairo_t *cr)
                      GTK_STATE_NORMAL, GTK_SHADOW_IN,
                      NULL, widget, "buttondefault",
                      0, 0, w, h);
-    
+
     }
   }
   return TRUE;
@@ -512,7 +510,7 @@ ol_osd_window_motion_notify (GtkWidget *widget, GdkEventMotion *event)
                                priv->old_width + priv->old_x - x,
                                height,
                                DRAG_WEST);
-                               
+
     break;
   case DRAG_NONE:
   {
@@ -888,7 +886,7 @@ ol_osd_window_compute_window_width (OlOsdWindow *osd)
   return w;
 }
 
-/** 
+/**
  * Computes the height of the OSD Window
  *
  * The computation relies on the height of OSD text and child widget. It should be
@@ -896,8 +894,8 @@ ol_osd_window_compute_window_width (OlOsdWindow *osd)
  * updated.
  *
  * Please note that the computed height does NOT consider the constrain of screen
- * @param osd 
- * 
+ * @param osd
+ *
  * @return The height of the widget
  */
 static int
@@ -918,7 +916,7 @@ ol_osd_window_compute_osd_height (OlOsdWindow *osd)
                  DEFAULT_HEIGHT);
   OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE (osd);
   int font_height = ol_osd_render_get_font_height (osd->render_context);
-  
+
   int height = font_height *
     (osd->line_count + (osd->line_count - 1) * LINE_PADDING) +
     ol_osd_render_get_outline_width (osd->render_context);
@@ -1435,7 +1433,7 @@ ol_osd_window_set_input_shape_mask (OlOsdWindow *osd, gboolean disable_input)
   GtkWidget *widget = GTK_WIDGET (osd);
   ol_assert (GTK_WIDGET_REALIZED (widget));
   if (disable_input)
-  {    
+  {
     GdkRegion *region = gdk_region_new ();
     gdk_window_input_shape_combine_region (GTK_WIDGET (osd)->window, region, 0, 0);
     gdk_region_destroy (region);
@@ -1446,14 +1444,14 @@ ol_osd_window_set_input_shape_mask (OlOsdWindow *osd, gboolean disable_input)
   }
 }
 
-/** 
+/**
  * Computes the position and size when constraining the window to be inside a screen
- * 
- * @param osd 
- * @param x 
- * @param y 
- * @param width 
- * @param height 
+ *
+ * @param osd
+ * @param x
+ * @param y
+ * @param width
+ * @param height
  * @param drag_state The hint of drag type. If the window is outside the screen,
  *                   drag_type determines how to constrain the window:
  *                   DRAG_MOVE: constrain the window by change position
@@ -1528,16 +1526,16 @@ ol_osd_window_queue_resize (OlOsdWindow *osd)
                              DRAG_NONE);
 }
 
-/** 
+/**
  * Move and resize the OSD Window.
  *
  * The coordinations and size are raw values, which means does not honor the size
  * of the child widget.
- * 
- * @param osd 
- * @param raw_x 
- * @param raw_y 
- * @param width 
+ *
+ * @param osd
+ * @param raw_x
+ * @param raw_y
+ * @param width
  * @param drag_state See long comment of ol_osd_window_compute_constrain
 */
 static void
@@ -1625,7 +1623,7 @@ ol_osd_window_class_init (OlOsdWindowClass *klass)
   gobject_class->get_property = ol_osd_window_get_property;
 
   object_class->destroy = ol_osd_window_destroy;
-  
+
   widget_class->size_allocate = ol_osd_window_size_allocate;
   widget_class->size_request = ol_osd_window_size_request;
   widget_class->enter_notify_event = ol_osd_window_enter_notify;
@@ -1693,89 +1691,114 @@ ol_osd_window_get_property (GObject *object, guint prop_id,
     break;
   }
 }
-  
+
 static void
 ol_osd_window_init (OlOsdWindow *osd)
 {
-  ol_log_func ();
-  GtkWindow *window = GTK_WINDOW (osd);
-  OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE (osd);
-  window->type = GTK_WINDOW_TOPLEVEL;
-  GValue allow_shrink = {0};
-  g_value_init (&allow_shrink, G_TYPE_BOOLEAN);
-  g_value_set_boolean (&allow_shrink, TRUE);
-  g_object_set_property (G_OBJECT (window), "allow-shrink", &allow_shrink);
-  g_value_unset (&allow_shrink);
-  
-  gtk_window_set_decorated (window, FALSE);
-  gtk_widget_set_app_paintable (GTK_WIDGET (osd), TRUE);
-  osd->current_line = 0;
-  osd->bg_pixbuf = NULL;
-  osd->line_count = 1;
-  int i;
-  for (i = 0; i < OL_OSD_WINDOW_MAX_LINE_COUNT; i++)
+  /* Allocate Private data structure */
+  (OL_OSD_WINDOW(osd))->priv = \
+      (OlOsdWindowPrivate *) g_malloc0(sizeof(OlOsdWindowPrivate));
+  /* If correctly allocated, initialize parameters */
+  if((OL_OSD_WINDOW(osd))->priv != NULL)
   {
-    osd->lyrics[i] = NULL;
-    osd->line_alignment[i] = 0.5;
-    osd->percentage[i] = 0.0;
-    priv->active_lyric_surfaces[i] = NULL;
-    priv->inactive_lyric_surfaces[i] = NULL;
-    osd->lyric_rects[i].x = 0;
-    osd->lyric_rects[i].y = 0;
-    osd->lyric_rects[i].width = 0;
-    osd->lyric_rects[i].height = 0;
+    ol_log_func ();
+    GtkWindow *window = GTK_WINDOW (osd);
+    OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE(osd);
+
+    window->type = GTK_WINDOW_TOPLEVEL;
+    GValue allow_shrink = {0};
+    g_value_init (&allow_shrink, G_TYPE_BOOLEAN);
+    g_value_set_boolean (&allow_shrink, TRUE);
+    g_object_set_property (G_OBJECT (window), "allow-shrink", &allow_shrink);
+    g_value_unset (&allow_shrink);
+
+    gtk_window_set_decorated (window, FALSE);
+    gtk_widget_set_app_paintable (GTK_WIDGET (osd), TRUE);
+    osd->current_line = 0;
+    osd->bg_pixbuf = NULL;
+    osd->line_count = 1;
+    int i;
+    for (i = 0; i < OL_OSD_WINDOW_MAX_LINE_COUNT; i++)
+    {
+      osd->lyrics[i] = NULL;
+      osd->line_alignment[i] = 0.5;
+      osd->percentage[i] = 0.0;
+      priv->active_lyric_surfaces[i] = NULL;
+      priv->inactive_lyric_surfaces[i] = NULL;
+      osd->lyric_rects[i].x = 0;
+      osd->lyric_rects[i].y = 0;
+      osd->lyric_rects[i].width = 0;
+      osd->lyric_rects[i].height = 0;
+    }
+    for (i = 0; i < OL_LINEAR_COLOR_COUNT; i++)
+    {
+      osd->active_colors[i] = DEFAULT_ACTIVE_COLORS[i];
+      osd->inactive_colors[i] = DEFAULT_INACTIVE_COLORS[i];
+    }
+    osd->render_context = ol_osd_render_context_new ();
+    osd->translucent_on_mouse_over = FALSE;
+    /* initilaize private data */
+    priv->shape_pixmap = NULL;
+    priv->width = DEFAULT_WIDTH;
+    priv->locked = TRUE;
+    priv->composited = FALSE;
+    priv->visible = FALSE;
+    priv->mouse_timer_id = 0;
+    priv->configure_event = 0;
+    priv->child_requisition.width = 0;
+    priv->child_requisition.height = 0;
+    priv->mouse_over_lyrics = FALSE;
+    priv->composited_signal = 0;
+    priv->raw_x = 0;
+    priv->raw_y = 0;
+    priv->drag_state = DRAG_NONE;
+    priv->update_shape = FALSE;
+    priv->blur_radius = 0.0;
+    /* ol_osd_window_set_mode (osd, OL_OSD_WINDOW_DOCK); */
+    ol_osd_window_set_mode (osd, OL_OSD_WINDOW_NORMAL);
+    ol_osd_window_update_colormap (osd);
+    ol_osd_window_screen_composited_changed (gtk_widget_get_screen (GTK_WIDGET (osd)),
+                                             osd);
+    gtk_widget_add_events(GTK_WIDGET(osd),
+                          GDK_BUTTON_PRESS_MASK |
+                          GDK_BUTTON_RELEASE_MASK |
+                          GDK_POINTER_MOTION_MASK);
+    g_signal_connect (G_OBJECT (osd), "button-press-event",
+                      G_CALLBACK (ol_osd_window_button_press), osd);
+    g_signal_connect (G_OBJECT (osd), "button-release-event",
+                      G_CALLBACK (ol_osd_window_button_release), osd);
+    g_signal_connect (G_OBJECT (osd), "motion-notify-event",
+                      G_CALLBACK (ol_osd_window_motion_notify), osd);
+    g_signal_connect (G_OBJECT (osd), "expose-event",
+                      G_CALLBACK (ol_osd_window_expose_before), osd);
+    g_signal_connect_after (G_OBJECT (osd), "expose-event",
+                            G_CALLBACK (ol_osd_window_expose_after), osd);
+    g_signal_connect (G_OBJECT (osd), "map-event",
+                      G_CALLBACK (ol_osd_window_map_cb), osd);
+    g_signal_connect (G_OBJECT (osd), "unmap-event",
+                      G_CALLBACK (ol_osd_window_unmap_cb), osd);
+    g_signal_connect (G_OBJECT (osd), "realize",
+                      G_CALLBACK (ol_osd_window_realize_cb), osd);
+    g_signal_connect (G_OBJECT (osd), "unrealize",
+                      G_CALLBACK (ol_osd_window_unrealize_cb), osd);
   }
-  for (i = 0; i < OL_LINEAR_COLOR_COUNT; i++)
-  {
-    osd->active_colors[i] = DEFAULT_ACTIVE_COLORS[i];
-    osd->inactive_colors[i] = DEFAULT_INACTIVE_COLORS[i];
-  }
-  osd->render_context = ol_osd_render_context_new ();
-  osd->translucent_on_mouse_over = FALSE;
-  /* initilaize private data */
-  priv->shape_pixmap = NULL;
-  priv->width = DEFAULT_WIDTH;
-  priv->locked = TRUE;
-  priv->composited = FALSE;
-  priv->visible = FALSE;
-  priv->mouse_timer_id = 0;
-  priv->configure_event = 0;
-  priv->child_requisition.width = 0;
-  priv->child_requisition.height = 0;
-  priv->mouse_over_lyrics = FALSE;
-  priv->composited_signal = 0;
-  priv->raw_x = 0;
-  priv->raw_y = 0;
-  priv->drag_state = DRAG_NONE;
-  priv->update_shape = FALSE;
-  priv->blur_radius = 0.0;
-  /* ol_osd_window_set_mode (osd, OL_OSD_WINDOW_DOCK); */
-  ol_osd_window_set_mode (osd, OL_OSD_WINDOW_NORMAL);
-  ol_osd_window_update_colormap (osd);
-  ol_osd_window_screen_composited_changed (gtk_widget_get_screen (GTK_WIDGET (osd)),
-                                           osd);
-  gtk_widget_add_events(GTK_WIDGET(osd),
-                        GDK_BUTTON_PRESS_MASK |
-                        GDK_BUTTON_RELEASE_MASK |
-                        GDK_POINTER_MOTION_MASK);
-  g_signal_connect (G_OBJECT (osd), "button-press-event",
-                    G_CALLBACK (ol_osd_window_button_press), osd);
-  g_signal_connect (G_OBJECT (osd), "button-release-event",
-                    G_CALLBACK (ol_osd_window_button_release), osd);
-  g_signal_connect (G_OBJECT (osd), "motion-notify-event",
-                    G_CALLBACK (ol_osd_window_motion_notify), osd);
-  g_signal_connect (G_OBJECT (osd), "expose-event",
-                    G_CALLBACK (ol_osd_window_expose_before), osd);
-  g_signal_connect_after (G_OBJECT (osd), "expose-event",
-                          G_CALLBACK (ol_osd_window_expose_after), osd);
-  g_signal_connect (G_OBJECT (osd), "map-event",
-                    G_CALLBACK (ol_osd_window_map_cb), osd);
-  g_signal_connect (G_OBJECT (osd), "unmap-event",
-                    G_CALLBACK (ol_osd_window_unmap_cb), osd);
-  g_signal_connect (G_OBJECT (osd), "realize",
-                    G_CALLBACK (ol_osd_window_realize_cb), osd);
-  g_signal_connect (G_OBJECT (osd), "unrealize",
-                    G_CALLBACK (ol_osd_window_unrealize_cb), osd);
+}
+
+static void
+ol_osd_window_dispose(GObject *object)
+{
+    OlOsdWindow *self = (OlOsdWindow *)object;
+    OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE(self);
+    /* Check if not NULL! To avoid calling dispose multiple times */
+    if(priv != NULL)
+    {
+        /* Deallocate contents of the private data, if any */
+        /* Deallocate private data structure */
+        g_free(priv);
+        /* And finally set the opaque pointer back to NULL, so that
+         *  we don't deallocate it twice. */
+        (OL_OSD_WINDOW(self))->priv = NULL;
+    }
 }
 
 GtkWidget*
@@ -1920,7 +1943,7 @@ void
 ol_osd_window_set_line_count (OlOsdWindow *osd,
                               guint line_count)
 {
-  ol_assert (OL_IS_OSD_WINDOW (osd)); 
+  ol_assert (OL_IS_OSD_WINDOW (osd));
   ol_assert (line_count >= 1 && line_count <= 2);
   osd->line_count = line_count;
   ol_osd_window_queue_resize (osd);
@@ -2020,7 +2043,7 @@ ol_osd_window_should_blur (OlOsdWindow *osd)
   return priv->composited || priv->mode == OL_OSD_WINDOW_NORMAL;
 }
 
-/** 
+/**
  * Sets the blur radius of renderer if possible.
  */
 static void

--- a/src/ol_osd_window.h
+++ b/src/ol_osd_window.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,13 +15,13 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * @file   ol_osd_window.h
  * @author Tiger Soldier <tigersoldi@gmail.com>
  * @date   Mon May 11 14:16:52 2009
- * 
+ *
  * @brief  The definition of an OlOsdWindow widget
  */
 #ifndef __OSD_WINDOW_H_
@@ -65,7 +65,7 @@ struct _OlOsdWindow
   OlOsdRenderContext *render_context;
   guint line_count;
   gboolean translucent_on_mouse_over;
-  
+  gpointer priv; /** Private data pointer */
 };
 
 struct _OlOsdWindowClass
@@ -76,30 +76,30 @@ struct _OlOsdWindowClass
 
 GtkType ol_osd_window_get_type (void);
 
-/** 
+/**
  * @brief Creates a new OSD Window.
  * To destroy the OSD Window, use g_object_unref
  */
 GtkWidget* ol_osd_window_new (void);
 
-/** 
+/**
  * @brief Sets witdh of an OSD window
- * 
+ *
  * @param osd An OlOsdWindow
  * @param width The width of the window
  */
 void ol_osd_window_set_width (OlOsdWindow *osd, gint width);
 int ol_osd_window_get_width (OlOsdWindow *osd);
-/** 
+/**
  * @brief Gets the size of an OSD window
- * 
+ *
  * @param osd An OlOsdWindow
  * @param width The width of the window, can be NULL
  * @param height The height of the window, can be NULL
  */
 void ol_osd_window_get_osd_size (OlOsdWindow *osd, gint *width, gint *height);
 
-/** 
+/**
  * @brief Sets whether an OSD window is locked
  * If an OSD window is locked, it can neither be moved by mouse, nor receive the mouse event.
  * Mouse events on it will be forwarded to the window below it.
@@ -109,16 +109,16 @@ void ol_osd_window_get_osd_size (OlOsdWindow *osd, gint *width, gint *height);
  * @param locked Whether the OSD window is locked or not
  */
 void ol_osd_window_set_locked (OlOsdWindow *osd, gboolean locked);
-/** 
+/**
  * @brief Gets whether an OSD window is locked
- * 
+ *
  * @param osd An OldOsdWindow
- * 
+ *
  * @return Whether the OSD window is locked or not
  */
 gboolean ol_osd_window_get_locked (OlOsdWindow *osd);
 
-/** 
+/**
  * @brief Sets the progress of the given lyric line
  * The color of the left part of the given lyric line will be changed, which makes the lyric KaraOK-like.
  * @param osd An OlOsdWindow
@@ -126,23 +126,23 @@ gboolean ol_osd_window_get_locked (OlOsdWindow *osd);
  * @param percentage The width percentage of the left part whose color is changed
  */
 void ol_osd_window_set_percentage (OlOsdWindow *osd, gint line, double percentage);
-/** 
+/**
  * @brief Sets the progress of the current lyric line
  * The color of the left part of the current lyric line will be changed, which makes the lyric KaraOK-like.
  * @param osd An OlOsdWindow
  * @param percentage The width percentage of the left part whose color is changed
  */
 void ol_osd_window_set_current_percentage (OlOsdWindow *osd, double percentage);
-/** 
+/**
  * @brief Gets the progress of the current lyric line
- * 
+ *
  * @param osd An OlOsdWindow
- * 
+ *
  * @return The width percentage of the left part whose color is changed
  */
 double ol_osd_window_get_current_percentage (OlOsdWindow *osd);
 
-/** 
+/**
  * @brief Sets the current line number
  * The current line is the lyric which is playing currently. The current lyric's color will be affected by
  * the current percentage set by ol_osd_window_set_current_percentage
@@ -150,16 +150,16 @@ double ol_osd_window_get_current_percentage (OlOsdWindow *osd);
  * @param line The line number of the current lyric, can be 0 or 1. 0 is the upper line and 1 is the lower
  */
 void ol_osd_window_set_current_line (OlOsdWindow *osd, gint line);
-/** 
+/**
  * @brief Gets the current line number
- * 
+ *
  * @param osd An OlOsdWindow
- * 
+ *
  * @return The line number of the current lyric.
  */
 gint ol_osd_window_get_current_line (OlOsdWindow *osd);
 
-/** 
+/**
  * @brief Set the lyric of certain line
  * If a line of lyric is set, it will changes to the lyric.
  * @param osd An OlOsdWindow
@@ -168,9 +168,9 @@ gint ol_osd_window_get_current_line (OlOsdWindow *osd);
  */
 void ol_osd_window_set_lyric (OlOsdWindow *osd, gint line, const char *lyric);
 
-/** 
+/**
  * @brief Set the horizontal alignment of a line
- * 
+ *
  * @param osd An OlOsdWindow
  * @param line The line that will be set. Can be 0 or 1.
  * @param alignment The alignment of the line, in the range of [0, 1].
@@ -178,18 +178,18 @@ void ol_osd_window_set_lyric (OlOsdWindow *osd, gint line, const char *lyric);
  */
 void ol_osd_window_set_line_alignment (OlOsdWindow *osd, gint line, double alignment);
 
-/** 
+/**
  * @brief Sets the font name for an OSD Window
- * 
+ *
  * This name includes style and size information as well. The format follows the
  * format in pango_font_description_from_string
- * 
+ *
  * @param osd An OlOsdWindow;
- * @param font_family Font name, 
+ * @param font_family Font name,
  */
 void ol_osd_window_set_font_name (OlOsdWindow *osd,
                                   const char *font_name);
-/** 
+/**
  * @brief Gets the font name for an OSD Window
  *
  * @param osd An OlOsdWindow
@@ -197,25 +197,25 @@ void ol_osd_window_set_font_name (OlOsdWindow *osd,
  */
 char* ol_osd_window_get_font_name (OlOsdWindow *osd);
 
-/** 
+/**
  * @brief Sets the outline width
- * 
+ *
  * @param osd An OSD window
  * @param width Outline width, must be positive
  */
 void ol_osd_window_set_outline_width (OlOsdWindow *osd,
                                       const int width);
 
-/** 
+/**
  * @brief Gets the outline width for an OSD Window
- * 
+ *
  * @param osd An OSD Window;
- * 
+ *
  * @return The outline width for the context
  */
 int ol_osd_window_get_outline_width (OlOsdWindow *osd);
 
-/** 
+/**
  * @brief Sets the color of active lyrics
  * Active lyric is the played part of the lyric
  * @param osd An OlOsdWindow
@@ -228,7 +228,7 @@ void ol_osd_window_set_active_colors (OlOsdWindow *osd,
                                       OlColor middle_color,
                                       OlColor bottom_color);
 
-/** 
+/**
  * @brief Sets the color of inactive lyrics
  * Inactive lyric is the lyric to be played
  * @param osd An OlOsdWindow
@@ -241,83 +241,83 @@ void ol_osd_window_set_inactive_colors (OlOsdWindow *osd,
                                         OlColor middle_color,
                                         OlColor bottom_color);
 
-/** 
+/**
  * @brief Sets the number of lyric lines to be displayed
- * 
+ *
  * @param osd An OlOsdWindow
  * @param line_count number of lines, in the range of [1,2]
  */
 void ol_osd_window_set_line_count (OlOsdWindow *osd,
                                    guint line_count);
-/** 
+/**
  * @brief Sets the number of lyric lines to be displayed
- * 
+ *
  * @param osd An OlOsdWindow
  * @return number of lines, in the range of [1,2]
  */
 guint ol_osd_window_get_line_count (OlOsdWindow *osd);
 
-/** 
+/**
  * @brief Sets whether the OSD window will be translucent when pointer is over it
- * 
+ *
  * @param osd An OlOsdWindow
  * @param value whether the osd will be translucent
  */
 void ol_osd_window_set_translucent_on_mouse_over (OlOsdWindow *osd,
                                                   gboolean value);
-/** 
+/**
  * @brief Gets whether the OSD window will be translucent when pointer is over it
- * 
+ *
  * @param osd An OlOsdWindow
  * @return whether the osd will be translucent
  */
 gboolean ol_osd_window_get_translucent_on_mouse_over (OlOsdWindow *osd);
 
-/** 
+/**
  * @brief Sets the background of the OSD window
  *
  * The background will display when the OSD Window is unlocked and
  * with user's mouse on it.
  *
- * @param osd 
+ * @param osd
  * @param bg The new background. The OSD window won't increase its ref
  *           count, but unref the old one. So if you want to keep the
  *           copy of the pixbuf, you need to ref it manually.
- * 
+ *
  */
 void ol_osd_window_set_bg (OlOsdWindow *osd, GdkPixbuf *bg);
 
 void ol_osd_window_set_mode (OlOsdWindow *osd, enum OlOsdWindowMode mode);
 
 enum OlOsdWindowMode ol_osd_window_get_mode (OlOsdWindow *osd);
-/** 
+/**
  * Moves osd window
  *
  * If the type of OSD window is OL_OSD_WINDOW_DOCK, the position of
  * window will be placed inside the screen.
- * 
- * @param osd 
- * @param x 
- * @param y 
+ *
+ * @param osd
+ * @param x
+ * @param y
  */
 void ol_osd_window_move (OlOsdWindow *osd, int x, int y);
 void ol_osd_window_get_pos (OlOsdWindow *osd, int *x, int *y);
 
-/** 
+/**
  * Sets the blur radius of the shadow of text.
  *
  * The outline will be blurred as shadow if radius is greater than 0.
- * @param osd 
+ * @param osd
  * @param radius The blur radius.
  */
 void ol_osd_window_set_blur_radius (OlOsdWindow *osd, double radius);
 
-/** 
+/**
  * Gets the blur radius of the shadow of text.
- * 
- * @param osd 
- * 
- * @return 
+ *
+ * @param osd
+ *
+ * @return
  */
 double ol_osd_window_get_blur_radius (OlOsdWindow *osd);
 #endif // __OSD_WINDOW_H__

--- a/src/ol_path_pattern.c
+++ b/src/ol_path_pattern.c
@@ -84,7 +84,7 @@ ol_path_get_lrc_pathname (const char *path_pattern,
   current += offset;
   if (ol_stricmp (&pathname[current - 4], ".lrc", 4) != 0)
   {
-    char *end = ol_strnncpy (pathname + current, len - current,
+    char *end = ol_memcpy (pathname + current, len - current,
                              ".lrc", 4);
     if (end == NULL)
       return -1;
@@ -129,7 +129,7 @@ ol_path_expand_file_pattern (const char *pattern,
     const char *ptr2 = strchr (ptr1, '%'); /* find place holder */
     if (ptr2 == NULL)                    /* no more place holders */
       ptr2 = pat_end; 
-    current = ol_strnncpy (current, end - current, ptr1, ptr2 - ptr1);
+    current = ol_memcpy (current, end - current, ptr1, ptr2 - ptr1);
     if (current == NULL)        /* The buffer is not big enough */
       return -1;
     if (ptr2 < pat_end)
@@ -176,7 +176,7 @@ ol_path_expand_file_pattern (const char *pattern,
         ol_debugf ("  append is NULL, pattern: %c\n", *(ptr2 + 1));
         return -1;
       }
-      current = ol_strnncpy (current, end - current,
+      current = ol_memcpy (current, end - current,
                              append, strlen (append));
       if (free_append)
         g_free ((char*)append);
@@ -224,7 +224,7 @@ ol_uri_get_filename (char *dest,
     if (ext != NULL)
       *ext = '\0';
   }
-  char *ret = ol_strnncpy (dest, dest_len, file_name, strlen (file_name));
+  char *ret = ol_memcpy (dest, dest_len, file_name, strlen (file_name));
   g_free (file_name);
   return ret;
 }
@@ -254,7 +254,7 @@ ol_uri_get_path (char *dest,
     dirname = g_path_get_dirname (pathname);
     g_free (pathname);
   }
-  char *ret = ol_strnncpy (dest, dest_len, dirname, strlen (dirname));
+  char *ret = ol_memcpy (dest, dest_len, dirname, strlen (dirname));
   g_free (dirname);
   return ret;
 }
@@ -280,17 +280,17 @@ ol_path_expand_path_pattern (const char *pattern,
   {
     const char *home_dir;
     home_dir = g_get_home_dir ();
-    char *end = ol_strnncpy (filename, len, home_dir, strlen (home_dir));
+    char *end = ol_memcpy (filename, len, home_dir, strlen (home_dir));
     if (end == NULL)
       return -1;
-    end = ol_strnncpy (end, filename + len - end,
+    end = ol_memcpy (end, filename + len - end,
                        pattern + 1, strlen (pattern + 1));
     if (end == NULL)
       return -1;
     return end - filename;
   }
   /* Others, copy directly */
-  char *end = ol_strnncpy (filename, len, pattern, strlen (pattern));
+  char *end = ol_memcpy (filename, len, pattern, strlen (pattern));
   if (end == NULL)
     return -1;
   else

--- a/src/ol_player.h
+++ b/src/ol_player.h
@@ -62,6 +62,7 @@ typedef struct _OlPlayerClass OlPlayerClass;
 struct _OlPlayer
 {
   GObject parent;
+  gpointer priv; /** Private data pointer */
 };
 
 struct _OlPlayerClass
@@ -71,11 +72,11 @@ struct _OlPlayerClass
 
 GType ol_player_get_type (void);
 
-/** 
+/**
  * Creates a new instance of OlPlayer
- * 
- * 
- * @return 
+ *
+ *
+ * @return
  */
 OlPlayer *ol_player_new (void);
 

--- a/src/ol_player_chooser.c
+++ b/src/ol_player_chooser.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "ol_player_chooser.h"
 #include "ol_app_chooser_widget.h"
@@ -25,10 +25,9 @@
 #include "ol_config_proxy.h"
 #include "ol_debug.h"
 
-#define OL_PLAYER_CHOOSER_GET_PRIVATE(obj)   (G_TYPE_INSTANCE_GET_PRIVATE  \
-                                              ((obj),                   \
-                                               ol_player_chooser_get_type (), \
-                                               OlPlayerChooserPrivate))
+#define OL_PLAYER_CHOOSER_GET_PRIVATE(obj) \
+    ((OlPlayerChooserPrivate *)((OL_PLAYER_CHOOSER(obj))->priv))
+
 static const guint SUPPORT_CHOOSER_INDEX = 0;
 static const guint ALL_CHOOSER_INDEX = 1;
 static const guint MAX_CHOOSER_HEIGHT = 96 * 3; /* about 3 lines of apps */
@@ -109,10 +108,34 @@ ol_player_chooser_class_init (OlPlayerChooserClass *klass)
 static void
 ol_player_chooser_init (OlPlayerChooser *window)
 {
-  OlPlayerChooserPrivate *priv = OL_PLAYER_CHOOSER_GET_PRIVATE (window);
-  priv->pages = g_ptr_array_new_with_free_func (g_free);
-  priv->page_button_group = NULL;
-  _setup_ui (window);
+  /* Allocate Private data structure */
+  (OL_PLAYER_CHOOSER(window))->priv = \
+    (OlPlayerChooserPrivate *) g_malloc0(sizeof(OlPlayerChooserPrivate));
+  /* If correctly allocated, initialize parameters */
+  if((OL_PLAYER_CHOOSER(window))->priv != NULL)
+  {
+    OlPlayerChooserPrivate *priv = OL_PLAYER_CHOOSER_GET_PRIVATE (window);
+    priv->pages = g_ptr_array_new_with_free_func (g_free);
+    priv->page_button_group = NULL;
+    _setup_ui (window);
+  }
+}
+
+static void
+ol_player_chooser_dispose(GObject *object)
+{
+    OlPlayerChooser *self = (OlPlayerChooser *)object;
+    OlPlayerChooserPrivate *priv = OL_PLAYER_CHOOSER_GET_PRIVATE(self);
+    /* Check if not NULL! To avoid calling dispose multiple times */
+    if(priv != NULL)
+    {
+        /* Deallocate contents of the private data, if any */
+        /* Deallocate private data structure */
+        g_free(priv);
+        /* And finally set the opaque pointer back to NULL, so that
+         *  we don't deallocate it twice. */
+        (OL_PLAYER_CHOOSER(self))->priv = NULL;
+    }
 }
 
 static void
@@ -212,7 +235,7 @@ _set_apps_to_page (OlPlayerChooser *window,
   gint box_height;
   gtk_widget_size_request (GTK_WIDGET (chooser), &chooser_req);
   gtk_widget_get_size_request (GTK_WIDGET (priv->chooser_panel), NULL, &box_height);
-  gint height = MIN (MAX_CHOOSER_HEIGHT, 
+  gint height = MIN (MAX_CHOOSER_HEIGHT,
                      MAX (chooser_req.height, box_height));
   if (height != box_height)
     gtk_widget_set_size_request (GTK_WIDGET (priv->chooser_panel),

--- a/src/ol_player_chooser.h
+++ b/src/ol_player_chooser.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_PLAYER_CHOOSER_H_
 #define _OL_PLAYER_CHOOSER_H_
@@ -42,6 +42,7 @@ typedef struct _OlPlayerChooserClass OlPlayerChooserClass;
 struct _OlPlayerChooser
 {
   GtkDialog parent;
+  gpointer priv;
 };
 
 struct _OlPlayerChooserClass
@@ -51,12 +52,12 @@ struct _OlPlayerChooserClass
 
 GtkType ol_player_chooser_get_type (void);
 
-/** 
+/**
  * Creates a new player chooser window.
- * 
+ *
  * @param supported_players List of *GAppInfo.
- * 
- * @return 
+ *
+ * @return
  */
 GtkWidget *ol_player_chooser_new (GList *supported_players);
 

--- a/src/ol_scroll_window.c
+++ b/src/ol_scroll_window.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <math.h>
 #include <glib.h>
@@ -28,11 +28,8 @@
 #include "ol_color.h"
 #include "ol_debug.h"
 
-
-#define OL_SCROLL_WINDOW_GET_PRIVATE(obj)    (G_TYPE_INSTANCE_GET_PRIVATE \
-                                              ((obj),                   \
-                                               ol_scroll_window_get_type (), \
-                                               OlScrollWindowPrivate))
+#define OL_SCROLL_WINDOW_GET_PRIVATE(obj) \
+   ((OlScrollWindowPrivate *)((OL_SCROLL_WINDOW(obj))->priv))
 
 /*************default setting******************/
 static const gint DEFAULT_WIDTH = 600;
@@ -140,66 +137,90 @@ ol_scroll_window_new ()
 static void
 ol_scroll_window_init (OlScrollWindow *self)
 {
-  /*basic*/
-  self->percentage = 0.0;
-  self->whole_lyrics = NULL;
-  self->current_lyric_id = -1;
-  /*privat data*/
-  OlScrollWindowPrivate *priv = OL_SCROLL_WINDOW_GET_PRIVATE (self);
-  priv->line_count = DEFAULT_LINE_COUNT;
-  priv->active_color = DEFAULT_ACTIVE_COLOR;
-  priv->inactive_color = DEFAULT_INACTIVE_COLOR;
-  priv->bg_color = DEFAULT_BG_COLOR;
-  priv->font_name = g_strdup (DEFAULT_FONT_NAME);
-  priv->line_margin = DEFAULT_LINE_MARGIN;
-  priv->padding_x = DEFAULT_PADDING_X;
-  priv->padding_y = DEFAULT_PADDING_Y;
-  priv->corner_radius = DEFAULT_CORNER_RADIUS;
-  priv->bg_opacity = DEFAULT_BG_OPACITY;
-  priv->frame_width = DEFAULT_FRAME_WIDTH;
-  priv->text = NULL;
-  priv->scroll_mode = OL_SCROLL_WINDOW_ALWAYS;
-  priv->can_seek = FALSE;
-  priv->seeking = FALSE;
-  /*set allocation*/
-  gtk_window_resize(GTK_WINDOW(self), DEFAULT_WIDTH, DEFAULT_HEIGHT);
-  gtk_widget_add_events (GTK_WIDGET (self),
-                         GDK_BUTTON_PRESS_MASK |
-                         GDK_BUTTON_RELEASE_MASK |
-                         GDK_POINTER_MOTION_MASK |
-                         GDK_POINTER_MOTION_HINT_MASK |
-                         GDK_DESTROY);
-  /* Set RGBA Colormap */
-  GdkScreen *screen = gtk_widget_get_screen (GTK_WIDGET (self));
-  GdkColormap* colormap = gdk_screen_get_rgba_colormap (screen);
-  if (colormap == NULL)
-    colormap = gdk_screen_get_rgb_colormap (screen);
-  gtk_widget_set_colormap (GTK_WIDGET (self), colormap);
-  gtk_window_set_decorated (GTK_WINDOW(self), FALSE);
-  gtk_widget_set_app_paintable (GTK_WIDGET (self), TRUE);
-  /* We need an additional widget to paint on */
-  priv->window_container = gtk_alignment_new (0.0, 0.0, 1.0, 1.0);
-  gtk_widget_set_redraw_on_allocate(priv->window_container, TRUE);
-  gtk_container_add (GTK_CONTAINER (self), priv->window_container);
-  /* Set toolbar container */
-  priv->toolbar_container = GTK_CONTAINER (gtk_alignment_new (1.0, 0.0, 0.0, 0.0));
-  gtk_alignment_set_padding (GTK_ALIGNMENT (priv->toolbar_container),
-                             priv->padding_x, priv->padding_x,
-                             priv->padding_x, priv->padding_x);
-  gtk_container_add (GTK_CONTAINER (priv->window_container),
-                     GTK_WIDGET (priv->toolbar_container));
-  gtk_widget_show_all (priv->window_container);
-  /* Set tooltips */
-  ol_scroll_window_update_tooltip (self);
-  /* Connect signals */
-  g_signal_connect (G_OBJECT (priv->window_container), "expose-event",
-                    G_CALLBACK (ol_scroll_window_expose), self);
-  g_signal_connect (G_OBJECT (self), "button-press-event",
-                    G_CALLBACK (ol_scroll_window_button_press), self);
-  g_signal_connect (G_OBJECT (self), "button-release-event",
-                    G_CALLBACK (ol_scroll_window_button_release), self);
-  g_signal_connect (G_OBJECT (self), "motion-notify-event",
-                    G_CALLBACK (ol_scroll_window_motion_notify), self);
+  /* Allocate Private data structure */
+  (OL_SCROLL_WINDOW(self))->priv = \
+      (OlScrollWindowPrivate *) g_malloc0(sizeof(OlScrollWindowPrivate));
+  /* If correctly allocated, initialize parameters */
+  if((OL_SCROLL_WINDOW(self))->priv != NULL)
+  {
+    /*basic*/
+    self->percentage = 0.0;
+    self->whole_lyrics = NULL;
+    self->current_lyric_id = -1;
+    /*privat data*/
+    OlScrollWindowPrivate *priv = OL_SCROLL_WINDOW_GET_PRIVATE (self);
+    priv->line_count = DEFAULT_LINE_COUNT;
+    priv->active_color = DEFAULT_ACTIVE_COLOR;
+    priv->inactive_color = DEFAULT_INACTIVE_COLOR;
+    priv->bg_color = DEFAULT_BG_COLOR;
+    priv->font_name = g_strdup (DEFAULT_FONT_NAME);
+    priv->line_margin = DEFAULT_LINE_MARGIN;
+    priv->padding_x = DEFAULT_PADDING_X;
+    priv->padding_y = DEFAULT_PADDING_Y;
+    priv->corner_radius = DEFAULT_CORNER_RADIUS;
+    priv->bg_opacity = DEFAULT_BG_OPACITY;
+    priv->frame_width = DEFAULT_FRAME_WIDTH;
+    priv->text = NULL;
+    priv->scroll_mode = OL_SCROLL_WINDOW_ALWAYS;
+    priv->can_seek = FALSE;
+    priv->seeking = FALSE;
+    /*set allocation*/
+    gtk_window_resize(GTK_WINDOW(self), DEFAULT_WIDTH, DEFAULT_HEIGHT);
+    gtk_widget_add_events (GTK_WIDGET (self),
+                           GDK_BUTTON_PRESS_MASK |
+                           GDK_BUTTON_RELEASE_MASK |
+                           GDK_POINTER_MOTION_MASK |
+                           GDK_POINTER_MOTION_HINT_MASK |
+                           GDK_DESTROY);
+    /* Set RGBA Colormap */
+    GdkScreen *screen = gtk_widget_get_screen (GTK_WIDGET (self));
+    GdkColormap* colormap = gdk_screen_get_rgba_colormap (screen);
+    if (colormap == NULL)
+      colormap = gdk_screen_get_rgb_colormap (screen);
+    gtk_widget_set_colormap (GTK_WIDGET (self), colormap);
+    gtk_window_set_decorated (GTK_WINDOW(self), FALSE);
+    gtk_widget_set_app_paintable (GTK_WIDGET (self), TRUE);
+    /* We need an additional widget to paint on */
+    priv->window_container = gtk_alignment_new (0.0, 0.0, 1.0, 1.0);
+    gtk_widget_set_redraw_on_allocate(priv->window_container, TRUE);
+    gtk_container_add (GTK_CONTAINER (self), priv->window_container);
+    /* Set toolbar container */
+    priv->toolbar_container = GTK_CONTAINER (gtk_alignment_new (1.0, 0.0, 0.0, 0.0));
+    gtk_alignment_set_padding (GTK_ALIGNMENT (priv->toolbar_container),
+                               priv->padding_x, priv->padding_x,
+                               priv->padding_x, priv->padding_x);
+    gtk_container_add (GTK_CONTAINER (priv->window_container),
+                       GTK_WIDGET (priv->toolbar_container));
+    gtk_widget_show_all (priv->window_container);
+    /* Set tooltips */
+    ol_scroll_window_update_tooltip (self);
+    /* Connect signals */
+    g_signal_connect (G_OBJECT (priv->window_container), "expose-event",
+                      G_CALLBACK (ol_scroll_window_expose), self);
+    g_signal_connect (G_OBJECT (self), "button-press-event",
+                      G_CALLBACK (ol_scroll_window_button_press), self);
+    g_signal_connect (G_OBJECT (self), "button-release-event",
+                      G_CALLBACK (ol_scroll_window_button_release), self);
+    g_signal_connect (G_OBJECT (self), "motion-notify-event",
+                      G_CALLBACK (ol_scroll_window_motion_notify), self);
+  }
+}
+
+static void
+ol_scroll_window_dispose(GObject *object)
+{
+    OlScrollWindow *self = (OlScrollWindow *)object;
+    OlScrollWindowPrivate *priv = OL_SCROLL_WINDOW_GET_PRIVATE (self);
+    /* Check if not NULL! To avoid calling dispose multiple times */
+    if(priv != NULL)
+    {
+        /* Deallocate contents of the private data, if any */
+        /* Deallocate private data structure */
+        g_free(priv);
+        /* And finally set the opaque pointer back to NULL, so that
+         *  we don't deallocate it twice. */
+        (OL_SCROLL_WINDOW(self))->priv = NULL;
+    }
 }
 
 static void
@@ -280,7 +301,7 @@ ol_scroll_window_expose (GtkWidget *widget,
   return FALSE;
 }
 
-void 
+void
 ol_scroll_window_set_whole_lyrics (OlScrollWindow *scroll,
                                    GPtrArray *whole_lyrics)
 {
@@ -480,7 +501,7 @@ _paint_lyrics (OlScrollWindow *scroll, cairo_t *cr)
   gint width, height;
   gdk_drawable_get_size (gtk_widget_get_window (GTK_WIDGET (scroll)),
                          &width, &height);
-  
+
   /* set the font */
   PangoLayout *layout = _get_pango (scroll, cr);
   pango_layout_set_alignment (layout, PANGO_ALIGN_LEFT);
@@ -526,7 +547,7 @@ _paint_lyrics (OlScrollWindow *scroll, cairo_t *cr)
         alpha = (height - line_height - priv->padding_y - ypos) * 1.0 / line_height * 2;
       if (alpha < 0.0) alpha = 0.0;
       cairo_set_source_rgba (cr,
-                             priv->active_color.r * ratio + 
+                             priv->active_color.r * ratio +
                              priv->inactive_color.r * (1 - ratio),
                              priv->active_color.g * ratio +
                              priv->inactive_color.g * (1 - ratio),
@@ -565,7 +586,7 @@ _paint_text (OlScrollWindow *scroll, cairo_t *cr)
   gint x, y;
   gdk_drawable_get_size (gtk_widget_get_window (widget),
                          &width, &height);
-  
+
   /* set the font */
   cairo_save (cr);
   cairo_set_source_rgb (cr,
@@ -629,7 +650,7 @@ ol_scroll_window_get_font_height (OlScrollWindow *scroll)
 {
   ol_assert_ret (OL_IS_SCROLL_WINDOW (scroll), 0);
   OlScrollWindowPrivate *priv = OL_SCROLL_WINDOW_GET_PRIVATE (scroll);
-  
+
   PangoContext *pango_context = gdk_pango_context_get ();
   PangoLayout *pango_layout = pango_layout_new (pango_context);
   PangoFontDescription *font_desc = pango_font_description_from_string (priv->font_name);
@@ -643,7 +664,7 @@ ol_scroll_window_get_font_height (OlScrollWindow *scroll)
   ascent = pango_font_metrics_get_ascent (metrics);
   descent = pango_font_metrics_get_descent (metrics);
   pango_font_metrics_unref (metrics);
-    
+
   height += PANGO_PIXELS (ascent + descent);
   pango_font_description_free (font_desc);
   g_object_unref (pango_layout);
@@ -651,7 +672,7 @@ ol_scroll_window_get_font_height (OlScrollWindow *scroll)
   return height;
 }
 
-int 
+int
 ol_scroll_window_get_current_lyric_id (OlScrollWindow *scroll)
 {
   ol_assert_ret (OL_IS_SCROLL_WINDOW (scroll), -1);
@@ -768,8 +789,8 @@ ol_scroll_window_begin_seek (OlScrollWindow *scroll,
   priv->saved_lyric_id = scroll->current_lyric_id;
 }
 
-static gboolean 
-ol_scroll_window_button_press (GtkWidget *widget, 
+static gboolean
+ol_scroll_window_button_press (GtkWidget *widget,
                                GdkEventButton *event)
 {
   ol_assert_ret (OL_IS_SCROLL_WINDOW (widget), FALSE);
@@ -796,8 +817,8 @@ ol_scroll_window_end_seek (OlScrollWindow *scroll)
   priv->seeking = FALSE;
 }
 
-static gboolean 
-ol_scroll_window_button_release (GtkWidget *widget, 
+static gboolean
+ol_scroll_window_button_release (GtkWidget *widget,
                                  GdkEventButton *event)
 {
   ol_assert_ret (OL_IS_SCROLL_WINDOW (widget), FALSE);

--- a/src/ol_scroll_window.h
+++ b/src/ol_scroll_window.h
@@ -4,7 +4,7 @@
  * Copyright (C) 2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __SCROLL_WINDOW_H_
 #define __SCROLL_WINDOW_H_
@@ -45,6 +45,7 @@ struct _OlScrollWindow
   double percentage;
   GPtrArray *whole_lyrics;
   gint current_lyric_id;
+  gpointer priv; /** Private data pointer */
 };
 
 
@@ -55,14 +56,14 @@ struct _OlScrollWindowClass
 
 GtkType ol_scroll_window_get_type (void);
 
-/** 
- * @brief create a new Scroll Window. 
+/**
+ * @brief create a new Scroll Window.
  * To destroy the Scroll Window, use g_object_unref
  */
 
 GtkWidget* ol_scroll_window_new (void);
 
-/** 
+/**
  * @brief Set the whole lyric of a song
  * If music changes,the whole lyrics of window will be changed.
  * @param scroll An OlScrollWindow
@@ -71,7 +72,7 @@ GtkWidget* ol_scroll_window_new (void);
  */
 void ol_scroll_window_set_whole_lyrics(OlScrollWindow *scroll,
                                        GPtrArray *whole_lyrics);
-/** 
+/**
  * @brief Sets the progress of the lyrics
  * @param scroll An OlScrollWindow
  * @param lyric_id The lyric_line which is currenty being displayed. -1  means the line has no lyric currently.
@@ -82,48 +83,48 @@ void ol_scroll_window_set_progress (OlScrollWindow *scroll,
                                     double percentage);
 
 
-/** 
+/**
  * @brief Gets the current line number
- * The current line is the lyric which is playing currently. 
+ * The current line is the lyric which is playing currently.
  * @param scroll An OlScrollWindow
  * @param line The line number of the current lyric, can be 0 or 1. 0 is the upper line and 1 is the lower
  */
 int ol_scroll_window_get_current_lyric_id (OlScrollWindow *scroll);
-/** 
+/**
  * @brief Sets the font family for an SCROLL Window
- * 
+ *
  * @param scroll An OlScrollWindow;
  * @param font_name Font family, must not be NULL. The font_name contains style and
  *        size information. Should be able to pass the value to
- *        pango_font_description_from_string() 
+ *        pango_font_description_from_string()
  */
 void ol_scroll_window_set_font_name (OlScrollWindow *scroll,
                                      const char *font_family);
-/** 
+/**
  * @brief Gets the font family for an SCROLL Window
- * 
+ *
  * @param scroll An OlScrollWindow
  * @return The font name, see the comment of ol_scroll_window_set_font_name
  */
 const char* ol_scroll_window_get_font_name (OlScrollWindow *scroll);
 
-/** 
+/**
  * Sets the text to be shown
  *
  * The text will be shown only if the lyrics are set to be NULL
- * @param scroll 
+ * @param scroll
  * @param text The text to be set, or NULL.
  */
 void ol_scroll_window_set_text (OlScrollWindow *scroll,
                                 const char *text);
 
-/** 
+/**
  * Sets the opacity of the background
- * 
- * @param scroll 
+ *
+ * @param scroll
  * @param opacity The opacity of the background. 0 being fully transparent
  *                and 1 meansfully opaque.
- * 
+ *
  */
 void ol_scroll_window_set_bg_opacity (OlScrollWindow *scroll,
                                       double opacity);

--- a/src/ol_utils.c
+++ b/src/ol_utils.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -163,7 +163,7 @@ ol_path_alloc(void)
   return ptr;
 }
 
-int 
+int
 ol_stricmp (const char *str1, const char *str2, const ssize_t count)
 {
   const char *ptr1 = str1;
@@ -228,7 +228,7 @@ ol_lcs (const char *str1, const char *str2)
 }
 
 char*
-ol_strnncpy (char *dest,
+ol_memcpy (char *dest,
              size_t dest_len,
              const char *src,
              size_t src_len)
@@ -243,7 +243,7 @@ ol_strnncpy (char *dest,
     dest[0] = '\0';
     return NULL;
   }
-  strncpy (dest, src, src_len);
+  memcpy (dest, src, src_len);
   dest[src_len] = '\0';
   return dest + src_len;
 }

--- a/src/ol_utils.h
+++ b/src/ol_utils.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __OL_UTILS_H__
 #define __OL_UTILS_H__
@@ -31,35 +31,35 @@ gint ol_get_int_from_hash_table (GHashTable *hash_table, const gchar *name);
 guint ol_get_uint_from_hash_table (GHashTable *hash_table, const gchar *name);
 gint64 ol_get_int64_from_hash_table (GHashTable *hash_table, const gchar *name);
 
-/** 
+/**
  * @brief Checks if a string is empty
  * A string is empty if it is NULL or contains only white spaces
  * @param str The string to be checked
- * 
+ *
  * @return If the string is empty, returns true
  */
 gboolean ol_is_string_empty (const char *str);
 
-/** 
+/**
  * @brief allocate memory for pathname, from APUE
- * 
+ *
  * @return pointer to this memory if success, or NULL. Should be free with free()
  */
 char* ol_path_alloc(void);
 
-/** 
+/**
  * @brief comparing str1 with str2 case insensitive
- * 
+ *
  * @param str1
  * @param str2
  * @param count The number of characters to be compared with, or -1 to compare
  *              the whole strings
- * 
+ *
  * @return the same with the function: strcmp in <string.h>
  */
 int ol_stricmp(const char *str1, const char *str2, const ssize_t count);
 
-/** 
+/**
  * @brief Copy the source string to the destination string
  * If the length to be coyped is larger than that of the destination string,
  * the copying will fail, and returns NULL.
@@ -67,106 +67,106 @@ int ol_stricmp(const char *str1, const char *str2, const ssize_t count);
  * @param dest_len The length of destination string, including '\0'
  * @param src Source string
  * @param src_len The length of source string to be copyed
- * 
+ *
  * @return The end of the destination if suceeded, or NULL if failed.
  */
-char* ol_strnncpy (char *dest,
+char* ol_memcpy (char *dest,
                    size_t dest_len,
                    const char *src,
                    size_t src_len);
 
-/** 
+/**
  * @Calculates the largest common substring for two strings
- * 
- * @param str1 
- * @param str2 
- * 
+ *
+ * @param str1
+ * @param str2
+ *
  * @return the length of the largest common substring
  */
 size_t ol_lcs (const char *str1, const char *str2);
 
-/** 
+/**
  * @Checks whether two strings are equale
  * Strings are different if one of them is NULL but another not,
  * or their content are different
- * 
+ *
  * @param str1 The first string or NULL
  * @param str2 The second string or NULL
- * 
+ *
  * @return TRUE if they are equal
  */
 int ol_streq (const char *str1, const char *str2);
 
-/** 
+/**
  * @Copy the content of a string pointer to another
- * 
+ *
  * @param dest The target string pointer. If it doesn't point to NULL, \
  * it will be free with g_free
  * @param src The source string. If it is not NULL, \
  * it will be copyed with g_strdup, the dupped string will be assigned to  \
  * dest. Otherwise the dest will be NULL after copied.
- * 
+ *
  * @return The string that dest points to after copying
  */
 char *ol_strptrcpy (char **dest, const char *src);
 
-/** 
+/**
  * @brief Find the first '\n', change it into '\0' and return the pointer to \
  *        the next line
- * 
+ *
  * @param str the string to be splited, cannot be NULL
- * 
+ *
  * @return The pointer to the next line. If no '\n' exists, return NULL
  */
 char *ol_split_a_line (char *str);
 
-/** 
+/**
  * @brief Fill the heading and tailing white spaces of str with '\0', \
  *        and returns the pointer to the first non-space character. \
  *        If the string is empty, simply return NULL
- * 
+ *
  * @param str The string to be trimed. If it is NULL, returns NULL.
- * 
+ *
  * @return The pointer to the first non-space character, \
  *         or NULL if str is empty or NULL.
  */
 char *ol_trim_string (char *str);
 
-/** 
+/**
  * @brief Check whether a file exists and is a regular file.
- * 
+ *
  * @param filename The path and fullname of the file
- * 
+ *
  * @return TRUE if the file in the path exists and is a regular file
  */
 gboolean ol_path_is_file (const char *filename);
 
-/** 
+/**
  * @brief Gets the length of a file
- * 
+ *
  * @param filename The full path of the file
- * 
+ *
  * @return The length of a file, or negative if error occurs
  */
 ssize_t ol_file_len (const char *filename);
 
-/** 
+/**
  * Converts a string to hex representation.
  *
  * @param data The string to encode
  * @param len The length to encode, or -1 if the string is NUL-terminated
- * 
+ *
  * @return The encoded string, should be freed with g_free.
  */
 char* ol_encode_hex (const char *data, ssize_t len);
 
-/** 
+/**
  * Split a path into two parts (root, ext), the ext is the extension of a file
  * name, which begins with a period and contains at most period. root + ext = path.
  *
  * If the filename begins with a period and has no extension, the filename will not
  * be stored in the ext part.
- * 
+ *
  * @param path The path to be splited.
  * @param root The path without ext. Should be freed with g_free.
  * @param ext The extension of filename, or NULL if no extension found.
@@ -174,40 +174,40 @@ char* ol_encode_hex (const char *data, ssize_t len);
  */
 void ol_path_splitext (const char *path, char **root, char **ext);
 
-/** 
+/**
  * Compares two GAppInfo according to its name.
  *
  * The comparison is case-insensitive
  *
- * @param a 
- * @param b 
- * 
+ * @param a
+ * @param b
+ *
  * @return 0 if the name of a equals to be.
  *         Negative if a is less than b.
  *         Otherwise a is greater than b.
  */
 gint ol_app_info_cmp (GAppInfo *a, GAppInfo *b);
 
-/** 
+/**
  * Launch a commandline from GAppInfo
- * 
+ *
  * @param cmdline The commandline to launch. %f and %U will be ignored
- * 
+ *
  * @return TRUE on successful launch, FALSE otherwise.
  */
 gboolean ol_launch_app (const char *cmdline);
 
-/** 
+/**
  * Pass names of all files and directories in the specified directory to given
  * function.
- * 
+ *
  * @param dir The path of the directroy
  * @param recursive Whether to visit subdirectories in the directory
  * @param traverse_func The function to receive the file name. traverse_func will be
  *                      called on each file once. If it returns FALSE, traversal will
  *                      be ended.
  * @param userdata
- * 
+ *
  * @return TRUE if the traversal is no interrupted because traverse_func returns
  *         FALSE. The return value is intend to be used in recursive traversal.
  */


### PR DESCRIPTION
The purpose of this PR is to eliminate all the compile-time warnings often generated by deprecations.

This PR applies mostly one change over and over throughout many files. The change is described in detail here: https://sigquit.wordpress.com/2009/02/13/avoid-g_type_instance_get_private-in-gobjects/

To be merged after https://github.com/osdlyrics/osdlyrics/pull/96