### PR TITLE
Addressed gtk deprecation warnings during compile time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: ./autogen.sh
 
       - name: Configure
-        run: ./configure --prefix=/usr PYTHON=/usr/bin/python3
+        run: ./configure --prefix=/usr PYTHON=/usr/bin/python3 CFLAGS="-DGTK_DISABLE_DEPRECATED"
 
       - name: Make
         run: make

--- a/src/ol_about.c
+++ b/src/ol_about.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,9 +15,12 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <gtk/gtk.h>
+#include <gtk/gtkwidget.h>
+#include <gtk/gtkdialog.h>
+#include <gtk/gtkaboutdialog.h>
+#include <gdk/gdkpixbuf.h>
 #include "config.h"
 #include "ol_intl.h"
 #include "ol_about.h"

--- a/src/ol_about.c
+++ b/src/ol_about.c
@@ -47,7 +47,7 @@ ol_about_close_clicked (GtkWidget *widget)
 {
   ol_log_func ();
   GtkWidget *toplevel = gtk_widget_get_toplevel (widget);
-  if (GTK_WIDGET_TOPLEVEL (toplevel))
+  if (gtk_widget_is_toplevel (toplevel))
   {
     gtk_widget_hide (toplevel);
   }

--- a/src/ol_app_chooser_widget.c
+++ b/src/ol_app_chooser_widget.c
@@ -53,15 +53,13 @@ static void _calc_size (guint count, guint *n_rows, guint *n_columns);
 static gint _app_info_cmp (GAppInfo **lhs, GAppInfo **rhs);
 static void ol_app_chooser_widget_destroy (GtkObject *object);
 
-G_DEFINE_TYPE (OlAppChooserWidget,
-               ol_app_chooser_widget,
-               GTK_TYPE_TABLE);
+G_DEFINE_TYPE_WITH_PRIVATE (OlAppChooserWidget,
+                            ol_app_chooser_widget,
+                            GTK_TYPE_TABLE);
 
 static void
 ol_app_chooser_widget_class_init (OlAppChooserWidgetClass *klass)
 {
-  g_type_class_add_private (G_OBJECT_CLASS (klass),
-                            sizeof (OlAppChooserWidgetPrivate));
   _signals[APP_ACTIVATE_SIGNAL] =
     g_signal_new ("app-activate",
                   OL_TYPE_APP_CHOOSER_WIDGET,

--- a/src/ol_app_chooser_widget.h
+++ b/src/ol_app_chooser_widget.h
@@ -21,7 +21,15 @@
 #ifndef _OL_APP_CHOOSER_WIDGET_H_
 #define _OL_APP_CHOOSER_WIDGET_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtkwidget.h>
+#include <gtk/gtktable.h>
+#include <gtk/gtkicontheme.h>
+#include <gtk/gtklabel.h>
+#include <gtk/gtkimage.h>
+#include <gtk/gtkvbox.h>
+#include <gtk/gtkframe.h>
+#include <gtk/gtkbutton.h>
+#include <gtk/gtkaspectframe.h>
 
 typedef struct {
   GtkWidget widget;

--- a/src/ol_app_chooser_widget.h
+++ b/src/ol_app_chooser_widget.h
@@ -30,6 +30,7 @@
 #include <gtk/gtkframe.h>
 #include <gtk/gtkbutton.h>
 #include <gtk/gtkaspectframe.h>
+#include <gtk/gtktypeutils.h>
 
 typedef struct {
   GtkWidget widget;
@@ -44,11 +45,11 @@ typedef struct {
 #define OL_TYPE_APP_CHOOSER_WIDGET                                      \
   ol_app_chooser_widget_get_type ()
 #define OL_APP_CHOOSER_WIDGET(obj)                                      \
-  GTK_CHECK_CAST (obj, OL_TYPE_APP_CHOOSER_WIDGET, OlAppChooserWidget)
+  G_TYPE_CHECK_INSTANCE_CAST (obj, OL_TYPE_APP_CHOOSER_WIDGET, OlAppChooserWidget)
 #define OL_APP_CHOOSER_WIDGET_CLASS(klass)                              \
   GTK_CHECK_CLASS_CAST (klass, OL_TYPE_APP_CHOOSER_WIDGET, OlAppChooserWidgetClass)
 #define OL_IS_APP_CHOOSER_WIDGET(obj)               \
-  GTK_CHECK_TYPE (obj, OL_TYPE_APP_CHOOSER_WIDGET)
+  G_TYPE_CHECK_INSTANCE_TYPE (obj, OL_TYPE_APP_CHOOSER_WIDGET)
 #define OL_APP_CHOOSER_WIDGET_GET_CLASS(obj)                            \
   (G_TYPE_INSTANCE_GET_CLASS ((obj),                                    \
                               OL_TYPE_APP_CHOOSER_WIDGET,               \

--- a/src/ol_cell_renderer_button.c
+++ b/src/ol_cell_renderer_button.c
@@ -104,7 +104,9 @@ struct _OlCellRendererButtonPrivate
   GtkWidget *entry;
 };
 
-G_DEFINE_TYPE (OlCellRendererButton, ol_cell_renderer_button, GTK_TYPE_CELL_RENDERER)
+G_DEFINE_TYPE_WITH_PRIVATE (OlCellRendererButton,
+                            ol_cell_renderer_button,
+                            GTK_TYPE_CELL_RENDERER)
 
 static void ol_cell_renderer_button_get_property (GObject *object,
                                            guint param_id,
@@ -224,8 +226,6 @@ ol_cell_renderer_button_class_init (OlCellRendererButtonClass *class)
                   g_cclosure_marshal_VOID__STRING,
                   G_TYPE_NONE, 1,
                   G_TYPE_STRING);
-
-  g_type_class_add_private (object_class, sizeof (OlCellRendererButtonPrivate));
 }
 
 static void

--- a/src/ol_cell_renderer_button.c
+++ b/src/ol_cell_renderer_button.c
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <gtk/gtkprivate.h>
+
 #include "ol_cell_renderer_button.h"
 #include "ol_marshal.h"
 #include "ol_debug.h"

--- a/src/ol_cell_renderer_button.c
+++ b/src/ol_cell_renderer_button.c
@@ -385,7 +385,7 @@ ol_cell_renderer_button_render (GtkCellRenderer      *cell,
   }
   else if ((flags & GTK_CELL_RENDERER_SELECTED) == GTK_CELL_RENDERER_SELECTED)
   {
-    if (GTK_WIDGET_HAS_FOCUS (widget))
+    if (gtk_widget_has_focus (widget))
       state |= GTK_STATE_SELECTED;
     else
       state |= GTK_STATE_ACTIVE;
@@ -396,7 +396,7 @@ ol_cell_renderer_button_render (GtkCellRenderer      *cell,
   }
   else
   {
-    if (GTK_WIDGET_STATE (widget) == GTK_STATE_INSENSITIVE)
+    if (gtk_widget_get_state (widget) == GTK_STATE_INSENSITIVE)
       state = GTK_STATE_INSENSITIVE;
     else
       state = GTK_STATE_NORMAL;

--- a/src/ol_cell_renderer_button.h
+++ b/src/ol_cell_renderer_button.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,12 +15,14 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_CELLRENDERERBUTTON_H_
 #define _OL_CELLRENDERERBUTTON_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtkcellrenderer.h>
+#include <gtk/gtkwidget.h>
+#include <gtk/gtkprivate.h>
 
 #define OL_TYPE_CELL_RENDERER_BUTTON		(ol_cell_renderer_button_get_type ())
 #define OL_CELL_RENDERER_BUTTON(obj)		(G_TYPE_CHECK_INSTANCE_CAST ((obj), OL_TYPE_CELL_RENDERER_BUTTON, OlCellRendererButton))

--- a/src/ol_config_proxy.c
+++ b/src/ol_config_proxy.c
@@ -47,7 +47,7 @@ typedef struct {
 static guint _signals[LAST_SINGAL];
 static OlConfigProxy *config_proxy = NULL;
 
-G_DEFINE_TYPE (OlConfigProxy, ol_config_proxy, G_TYPE_DBUS_PROXY);
+G_DEFINE_TYPE_WITH_PRIVATE (OlConfigProxy, ol_config_proxy, G_TYPE_DBUS_PROXY);
 
 static OlConfigProxy *ol_config_proxy_new (void);
 static void ol_config_proxy_finalize (GObject *object);
@@ -124,8 +124,6 @@ ol_config_proxy_class_init (OlConfigProxyClass *klass)
 {
   GObjectClass *gobject_class;
   GDBusProxyClass *proxy_class;
-
-  g_type_class_add_private (klass, sizeof (OlConfigProxyPrivate));
 
   gobject_class = G_OBJECT_CLASS (klass);
   gobject_class->finalize = ol_config_proxy_finalize;

--- a/src/ol_gui.h
+++ b/src/ol_gui.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,19 +15,20 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_GUI_H_
 #define _OL_GUI_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtkwidget.h>
+#include <gtk/gtkbuilder.h>
 
-/** 
+/**
  * @brief Gets a widget in Glade file by name
- * 
+ *
  * @param name name of the widget
- * 
- * @return 
+ *
+ * @return
  */
 GtkWidget *ol_gui_get_widget (const char *name);
 

--- a/src/ol_image_button.c
+++ b/src/ol_image_button.c
@@ -36,7 +36,7 @@ struct _OlImageButtonPriv
   GdkPixbuf *image;
 };
 
-G_DEFINE_TYPE (OlImageButton, ol_image_button, GTK_TYPE_BUTTON);
+G_DEFINE_TYPE_WITH_PRIVATE (OlImageButton, ol_image_button, GTK_TYPE_BUTTON);
 
 static void ol_image_button_destroy (GtkObject *object);
 static void ol_image_button_size_request (GtkWidget *widget,
@@ -138,7 +138,6 @@ ol_image_button_expose (GtkWidget *widget,
 static void
 ol_image_button_class_init (OlImageButtonClass *klass)
 {
-  g_type_class_add_private (klass, sizeof (OlImageButtonPriv));
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
   GtkObjectClass *object_class = GTK_OBJECT_CLASS (klass);
 

--- a/src/ol_image_button.c
+++ b/src/ol_image_button.c
@@ -77,7 +77,7 @@ ol_image_button_size_allocate (GtkWidget     *widget,
   GtkButton *button = GTK_BUTTON (widget);
   widget->allocation = *allocation;
 
-  if (GTK_WIDGET_REALIZED (widget))
+  if (gtk_widget_get_realized (widget))
     gdk_window_move_resize (button->event_window,
 			    widget->allocation.x,
 			    widget->allocation.y,
@@ -119,7 +119,7 @@ ol_image_button_expose (GtkWidget *widget,
     cairo_clip (cr);
 
     int img_index = STATE_NORMAL;
-    GtkStateType state = GTK_WIDGET_STATE (widget);
+    GtkStateType state = gtk_widget_get_state (widget);
     if (state == GTK_STATE_ACTIVE)
       img_index = STATE_PRESSED;
     else if (state == GTK_STATE_PRELIGHT || state == GTK_STATE_SELECTED)

--- a/src/ol_image_button.h
+++ b/src/ol_image_button.h
@@ -30,12 +30,18 @@
 #define OL_IMAGE_BUTTON_GET_CLASS(obj)        (G_TYPE_INSTANCE_GET_CLASS ((obj), ol_image_button_get_type (), OlImageButtonClass))
 
 typedef struct _OlImageButton OlImageButton;
+typedef struct _OlImageButtonPrivate OlImageButtonPrivate;
 typedef struct _OlImageButtonClass OlImageButtonClass;
 
 struct _OlImageButton
 {
   GtkButton button;
   gpointer priv; /** Private data pointer */
+};
+
+struct _OlImageButtonPrivate
+{
+
 };
 
 struct _OlImageButtonClass

--- a/src/ol_image_button.h
+++ b/src/ol_image_button.h
@@ -23,10 +23,11 @@
 #include <gtk/gtkbutton.h>
 #include <gtk/gtkwidget.h>
 #include <gtk/gtkobject.h>
+#include <gtk/gtktypeutils.h>
 
-#define OL_IMAGE_BUTTON(obj)                  GTK_CHECK_CAST (obj, ol_image_button_get_type (), OlImageButton)
+#define OL_IMAGE_BUTTON(obj)                  G_TYPE_CHECK_INSTANCE_CAST (obj, ol_image_button_get_type (), OlImageButton)
 #define OL_IMAGE_BUTTON_CLASS(klass)          GTK_CHECK_CLASS_CAST (klass, ol_image_button_get_type (), OlImageButtonClass)
-#define OL_IS_IMAGE_BUTTON(obj)               GTK_CHECK_TYPE (obj, ol_image_button_get_type ())
+#define OL_IS_IMAGE_BUTTON(obj)               G_TYPE_CHECK_INSTANCE_TYPE (obj, ol_image_button_get_type ())
 #define OL_IMAGE_BUTTON_GET_CLASS(obj)        (G_TYPE_INSTANCE_GET_CLASS ((obj), ol_image_button_get_type (), OlImageButtonClass))
 
 typedef struct _OlImageButton OlImageButton;
@@ -49,7 +50,7 @@ struct _OlImageButtonClass
   GtkButtonClass button_class;
 };
 
-GtkType ol_image_button_get_type (void);
+GType ol_image_button_get_type (void);
 
 /**
  * @brief Create a new image button

--- a/src/ol_image_button.h
+++ b/src/ol_image_button.h
@@ -20,7 +20,9 @@
 #ifndef _OL_IMAGE_BUTTON_H_
 #define _OL_IMAGE_BUTTON_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtkbutton.h>
+#include <gtk/gtkwidget.h>
+#include <gtk/gtkobject.h>
 
 #define OL_IMAGE_BUTTON(obj)                  GTK_CHECK_CAST (obj, ol_image_button_get_type (), OlImageButton)
 #define OL_IMAGE_BUTTON_CLASS(klass)          GTK_CHECK_CLASS_CAST (klass, ol_image_button_get_type (), OlImageButtonClass)

--- a/src/ol_keybindings.h
+++ b/src/ol_keybindings.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,19 +15,20 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * @file   ol_keybinding.h
  * @author Tiger Soldier <tigersoldi@gmail.com>
  * @date   Sun Aug 16 15:58:56 2009
- * 
+ *
  * @brief  Global Keybinding settings
  */
 #ifndef _OL_KEYBINDING_H_
 #define _OL_KEYBINDING_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtkaccelmap.h>
+#include <gtk/gtkaccelgroup.h>
 
 void ol_keybinding_init ();
 GtkAccelGroup* ol_keybinding_get_accel_group ();

--- a/src/ol_lrc.c
+++ b/src/ol_lrc.c
@@ -70,14 +70,13 @@ static struct OlLrcItem *ol_lrc_iter_get_item (OlLrcIter *iter);
 /* ---------------Save offset functions ----------------- */
 static gboolean _save_offset_timeout (OlLrc *lrc);
 
-G_DEFINE_TYPE (OlLrc, ol_lrc, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE (OlLrc, ol_lrc, G_TYPE_OBJECT);
 
 static void
 ol_lrc_class_init (OlLrcClass *klass)
 {
   GObjectClass *gklass = G_OBJECT_CLASS (klass);
   gklass->finalize = ol_lrc_finalize;
-  g_type_class_add_private (klass, sizeof (OlLrcPrivate));
 }
 
 static void

--- a/src/ol_lyric_candidate_list.h
+++ b/src/ol_lyric_candidate_list.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2012  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,12 +15,15 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_LYRIC_CANDIDATE_LIST_H_
 #define _OL_LYRIC_CANDIDATE_LIST_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtktreeview.h>
+#include <gtk/gtktreestore.h>
+#include <gtk/gtktreeselection.h>
+#include <gtk/gtkcellrenderertext.h>
 #include "ol_lyric_source.h"
 
 void ol_lyric_candidate_list_init (GtkTreeView *list,

--- a/src/ol_lyric_candidate_selector.h
+++ b/src/ol_lyric_candidate_selector.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2012  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,10 +15,14 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_LYRIC_CANDIDATE_SELECTOR_H_
 #define _OL_LYRIC_CANDIDATE_SELECTOR_H_
+
+#include <gtk/gtkbutton.h>
+#include <gtk/gtktogglebutton.h>
+#include <gtk/gtktreeselection.h>
 
 #include "ol_metadata.h"
 #include "ol_lyric_source.h"

--- a/src/ol_lyric_source.c
+++ b/src/ol_lyric_source.c
@@ -28,14 +28,14 @@
 G_DEFINE_TYPE (OlLyricSource, ol_lyric_source, G_TYPE_DBUS_PROXY);
 G_DEFINE_TYPE (OlLyricSourceTask, ol_lyric_source_task, G_TYPE_OBJECT);
 G_DEFINE_TYPE (OlLyricSourceSearchTask,
-               ol_lyric_source_search_task,
-               OL_TYPE_LYRIC_SOURCE_TASK);
+              ol_lyric_source_search_task,
+              OL_TYPE_LYRIC_SOURCE_TASK);
 G_DEFINE_TYPE (OlLyricSourceDownloadTask,
-               ol_lyric_source_download_task,
-               OL_TYPE_LYRIC_SOURCE_TASK);
+              ol_lyric_source_download_task,
+              OL_TYPE_LYRIC_SOURCE_TASK);
 G_DEFINE_TYPE (OlLyricSourceCandidate,
-               ol_lyric_source_candidate,
-               G_TYPE_OBJECT);
+              ol_lyric_source_candidate,
+              G_TYPE_OBJECT);
 
 #define OL_LYRIC_SOURCE_GET_PRIVATE(obj) \
   ((OlLyricSourcePrivate *)((OL_LYRIC_SOURCE(obj))->priv))
@@ -186,7 +186,6 @@ ol_lyric_source_class_init (OlLyricSourceClass *klass)
   proxy_class = G_DBUS_PROXY_CLASS (klass);
   object_class->finalize = ol_lyric_source_finalize;
   proxy_class->g_signal = ol_lyric_source_g_signal;
-  g_type_class_add_private (klass, sizeof (OlLyricSourcePrivate));
 }
 
 static void
@@ -662,7 +661,6 @@ ol_lyric_source_candidate_class_init (OlLyricSourceCandidateClass *klass)
   object_class->get_property = ol_lyric_source_candidate_get_property;
   object_class->set_property = ol_lyric_source_candidate_set_property;
   object_class->finalize = ol_lyric_source_candidate_finalize;
-  g_type_class_add_private (klass, sizeof (OlLyricSourceCandidatePrivate));
   g_object_class_install_property (object_class,
                                    CANDIDATE_PROP_TITLE,
                                    g_param_spec_string ("title",
@@ -971,7 +969,6 @@ ol_lyric_source_task_class_init (OlLyricSourceTaskClass *klass)
   object_class->get_property = ol_lyric_source_task_get_property;
   object_class->finalize = ol_lyric_source_task_finalize;
   klass->cancel = NULL;
-  g_type_class_add_private (klass, sizeof (OlLyricSourceTaskPrivate));
   g_object_class_install_property (object_class,
                                    TASK_PROP_SOURCE,
                                    g_param_spec_object ("source",

--- a/src/ol_lyric_source.h
+++ b/src/ol_lyric_source.h
@@ -156,6 +156,7 @@ typedef struct _OlLyricSourceCandidate OlLyricSourceCandidate;
 typedef struct _OlLyricSourceCandidateClass OlLyricSourceCandidateClass;
 
 typedef struct _OlLyricSourceInfo OlLyricSourceInfo;
+
 struct _OlLyricSourceInfo;
 
 /**

--- a/src/ol_lyric_source_list.h
+++ b/src/ol_lyric_source_list.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2012  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,32 +15,34 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_LYRIC_SOURCE_LIST_H_
 #define _OL_LYRIC_SOURCE_LIST_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtktreeview.h>
+#include <gtk/gtkcellrenderertoggle.h>
+#include <gtk/gtkcellrenderertext.h>
 
 void ol_lyric_source_list_init (GtkTreeView *list);
 
-/** 
+/**
  * Sets source list with source info
  *
  * The sources will be listed in the order of the position in the list.
- * @param list 
+ * @param list
  * @param info_list A list of OlLyricSourceInfo*.
  */
 void ol_lyric_source_list_set_info_list (GtkTreeView *list,
                                          GList *info_list);
-/** 
+/**
  * Gets a list of id of enabled sources
  *
  * The returned list can be passed as the `source_ids` parameter in
  * ol_lyric_source_search().
- * 
+ *
  * @param list The engine list widget
- * 
+ *
  * @return A list of gchar*. The elements in the list are id of enabled
  * sources. You must free the elemenets with g_free(), and free the list.
  */

--- a/src/ol_lyrics.c
+++ b/src/ol_lyrics.c
@@ -27,7 +27,7 @@ static void ol_lyrics_g_signal (GDBusProxy *proxy,
 static OlLrc *ol_lyrics_get_lrc_from_variant (OlLyrics *proxy,
                                               GVariant *variant);
 
-G_DEFINE_TYPE (OlLyrics, ol_lyrics, G_TYPE_DBUS_PROXY);
+G_DEFINE_TYPE_WITH_PRIVATE (OlLyrics, ol_lyrics, G_TYPE_DBUS_PROXY);
 
 static void
 ol_lyrics_init (OlLyrics *proxy)
@@ -45,8 +45,6 @@ ol_lyrics_class_init (OlLyricsClass *klass)
 {
   GObjectClass *gobject_class;
   GDBusProxyClass *proxy_class;
-
-  g_type_class_add_private (klass, sizeof (OlLyricsPrivate));
 
   gobject_class = G_OBJECT_CLASS (klass);
   gobject_class->finalize     = ol_lyrics_finalize;

--- a/src/ol_main.c
+++ b/src/ol_main.c
@@ -14,7 +14,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <sys/types.h>
@@ -23,6 +23,7 @@
 #include <signal.h>
 #include <pwd.h>
 #include <gio/gio.h>
+#include <gtk/gtkmain.h>
 #include "config.h"
 #include "ol_lrc.h"
 #include "ol_player.h"

--- a/src/ol_menu.h
+++ b/src/ol_menu.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,16 +15,23 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_MENU_H_
 #define _OL_MENU_H_
-#include <gtk/gtk.h>
+#include <gtk/gtkwidget.h>
+#include <gtk/gtkdialog.h>
+#include <gtk/gtkfilechooser.h>
+#include <gtk/gtkfilechooserdialog.h>
+#include <gtk/gtkcheckmenuitem.h>
+#include <gtk/gtkmenuitem.h>
+#include <gtk/gtkstock.h>
+#include <gtk/gtkmain.h>
 
-/** 
+/**
  * @brief Gets singleton popup menu
  * The popup menu will be created at the first invoke
- * 
+ *
  * @return The popup menu for the app
  */
 GtkWidget* ol_menu_get_popup ();

--- a/src/ol_option.c
+++ b/src/ol_option.c
@@ -32,6 +32,7 @@
 #include <gtk/gtkrange.h>
 #include <gtk/gtkmenuitem.h>
 #include <gtk/gtkcombobox.h>
+#include <gtk/gtkcomboboxtext.h>
 #include <gtk/gtkbox.h>
 #include <gtk/gtkbbox.h>
 #include <gtk/gtklabel.h>
@@ -42,6 +43,7 @@
 #include <gtk/gtkicontheme.h>
 #include <gtk/gtkversion.h>
 #include <gtk/gtkmain.h>
+#include <gtk/gtkcomboboxtext.h>
 
 #include "ol_option.h"
 #include "ol_about.h"
@@ -1387,7 +1389,7 @@ void
 ol_option_close_clicked (GtkWidget *widget)
 {
   GtkWidget *toplevel = gtk_widget_get_toplevel (widget);
-  if (GTK_WIDGET_TOPLEVEL (toplevel))
+  if (gtk_widget_is_toplevel (toplevel))
   {
     gtk_widget_hide (toplevel);
   }
@@ -1625,10 +1627,10 @@ _disconnect_download_engine_changed (GtkTreeView *list,
 static void
 init_startup_player (GtkWidget *widget)
 {
-  GtkComboBox *cb = GTK_COMBO_BOX (widget);
+  GtkComboBoxText *cb = GTK_COMBO_BOX_TEXT (widget);
   if (cb == NULL)
     return;
-  gtk_combo_box_append_text (cb, _("Choose on startup"));
+  gtk_combo_box_text_append_text (cb, _("Choose on startup"));
   GtkListStore *liststore = GTK_LIST_STORE (gtk_combo_box_get_model (GTK_COMBO_BOX (widget)));
   /* TODO: */
   GList *players = NULL;
@@ -1645,12 +1647,8 @@ init_startup_player (GtkWidget *widget)
                         -1);
     g_object_unref (G_OBJECT (app_info));
   }
-  /* gtk_list_store_append (liststore, &iter); */
-  /* gtk_list_store_set (liststore, &iter, */
-  /*                     0, "Customize", */
-  /*                     1, "", */
-  /*                     -1); */
-  gtk_combo_box_append_text (cb, _("Customize"));
+
+  gtk_combo_box_text_append_text (cb, _("Customize"));
 }
 
 static void

--- a/src/ol_option.c
+++ b/src/ol_option.c
@@ -19,12 +19,30 @@
  */
 #include <string.h>
 #include <gtk/gtkwidget.h>
+#include <gtk/gtkdialog.h>
+#include <gtk/gtkcellrenderertext.h>
 #include <gtk/gtktree.h>
+#include <gtk/gtktreeselection.h>
 #include <gtk/gtktreeview.h>
 #include <gtk/gtkcellrenderer.h>
 #include <gtk/gtktogglebutton.h>
+#include <gtk/gtkspinbutton.h>
+#include <gtk/gtkcolorbutton.h>
+#include <gtk/gtkfontbutton.h>
+#include <gtk/gtkrange.h>
+#include <gtk/gtkmenuitem.h>
 #include <gtk/gtkcombobox.h>
 #include <gtk/gtkbox.h>
+#include <gtk/gtkbbox.h>
+#include <gtk/gtklabel.h>
+#include <gtk/gtkstock.h>
+#include <gtk/gtkscale.h>
+#include <gtk/gtkfilechooser.h>
+#include <gtk/gtkfilechooserdialog.h>
+#include <gtk/gtkicontheme.h>
+#include <gtk/gtkversion.h>
+#include <gtk/gtkmain.h>
+
 #include "ol_option.h"
 #include "ol_about.h"
 #include "ol_gui.h"

--- a/src/ol_option.c
+++ b/src/ol_option.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldi@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,10 +15,16 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <string.h>
-#include <gtk/gtk.h>
+#include <gtk/gtkwidget.h>
+#include <gtk/gtktree.h>
+#include <gtk/gtktreeview.h>
+#include <gtk/gtkcellrenderer.h>
+#include <gtk/gtktogglebutton.h>
+#include <gtk/gtkcombobox.h>
+#include <gtk/gtkbox.h>
 #include "ol_option.h"
 #include "ol_about.h"
 #include "ol_gui.h"
@@ -405,7 +411,7 @@ ol_option_osd_alignment_changed (GtkRange *range,
       char buffer[24];
       sprintf (buffer, "OSD/lrc-align-%d", i);
       ol_config_proxy_set_double (ol_config_proxy_get_instance (),
-                                  buffer, 
+                                  buffer,
                                   gtk_range_get_value (range));
 
     }
@@ -578,7 +584,7 @@ ol_option_path_clicked (GtkButton *button,
   ol_assert (lrc_path_widgets.entry != NULL);
   const char *current_path = gtk_entry_get_text (GTK_ENTRY (lrc_path_widgets.entry));
   if (strcmp (current_path, "%s") != 0)
-  {  
+  {
     ol_debugf ("  current path:%s\n", current_path);
     char expanded_path[BUFFER_SIZE];
     /* expand `~' to home directory*/
@@ -768,7 +774,7 @@ init_signals ()
       continue;
     for (; value->widget_name != NULL && value->value != NULL; value++)
     {
-      GtkToggleButton *radio_button = GTK_TOGGLE_BUTTON (ol_gui_get_widget (value->widget_name)); 
+      GtkToggleButton *radio_button = GTK_TOGGLE_BUTTON (ol_gui_get_widget (value->widget_name));
       if (radio_button != NULL)
       {
         g_signal_connect (G_OBJECT (radio_button),
@@ -790,7 +796,7 @@ init_signals ()
                         &toggle_properties[i]);
     }
   }
-  
+
   for (i = 0; i < G_N_ELEMENTS (entry_str_options); i++)
   {
     GtkWidget *widget = ol_gui_get_widget (entry_str_options[i].widget_name);
@@ -813,7 +819,7 @@ init_signals ()
                         &spin_int_options[i]);
     }
   }
-  
+
   for (i = 0; i < G_N_ELEMENTS (scale_double_options); i++)
   {
     GtkWidget *widget = ol_gui_get_widget (scale_double_options[i].widget_name);
@@ -825,7 +831,7 @@ init_signals ()
                         &scale_double_options[i]);
     }
   }
-  
+
   for (i = 0; i < G_N_ELEMENTS (color_str_options); i++)
   {
     GtkWidget *widget = ol_gui_get_widget (color_str_options[i].widget_name);
@@ -837,7 +843,7 @@ init_signals ()
                         &color_str_options[i]);
     }
   }
-  
+
   for (i = 0; i < G_N_ELEMENTS (font_str_options); i++)
   {
     GtkWidget *widget = ol_gui_get_widget (font_str_options[i].widget_name);
@@ -849,7 +855,7 @@ init_signals ()
                         &font_str_options[i]);
     }
   }
-  
+
   for (i = 0; i < G_N_ELEMENTS (combo_str_options); i++)
   {
     GtkWidget *widget = ol_gui_get_widget (combo_str_options[i].widget_name);
@@ -1019,10 +1025,10 @@ load_check_button_options ()
     return;
   for (i = 0; i < G_N_ELEMENTS (check_button_options); i++)
   {
-    GtkToggleButton *check_button = GTK_TOGGLE_BUTTON (ol_gui_get_widget (check_button_options[i].widget_name)); 
+    GtkToggleButton *check_button = GTK_TOGGLE_BUTTON (ol_gui_get_widget (check_button_options[i].widget_name));
     if (check_button_options != NULL)
     {
-      gtk_toggle_button_set_active (check_button, 
+      gtk_toggle_button_set_active (check_button,
                                     ol_config_proxy_get_bool (config,
                                                               check_button_options[i].key));
 
@@ -1064,7 +1070,7 @@ load_radio_str_options ()
     }
     if (value->widget_name == NULL || value->value == NULL)
       value = radio_str_options[i].values;
-    GtkToggleButton *radio_button = GTK_TOGGLE_BUTTON (ol_gui_get_widget (value->widget_name)); 
+    GtkToggleButton *radio_button = GTK_TOGGLE_BUTTON (ol_gui_get_widget (value->widget_name));
     if (radio_button != NULL)
     {
       gtk_toggle_button_set_active (radio_button, TRUE);
@@ -1086,7 +1092,7 @@ load_entry_str_options ()
                                                      entry_str_options[i].key);
     if (config_value == NULL)
       continue;
-    GtkEntry *entry = GTK_ENTRY (ol_gui_get_widget (entry_str_options[i].widget_name)); 
+    GtkEntry *entry = GTK_ENTRY (ol_gui_get_widget (entry_str_options[i].widget_name));
     if (entry != NULL)
     {
       gtk_entry_set_text (entry, config_value);
@@ -1106,7 +1112,7 @@ load_spin_int_options ()
   {
     int config_value = ol_config_proxy_get_int (config,
                                                 spin_int_options[i].key);
-    GtkSpinButton *spin = GTK_SPIN_BUTTON (ol_gui_get_widget (spin_int_options[i].widget_name)); 
+    GtkSpinButton *spin = GTK_SPIN_BUTTON (ol_gui_get_widget (spin_int_options[i].widget_name));
     if (spin != NULL)
     {
       gtk_spin_button_set_value (spin, config_value);
@@ -1267,7 +1273,7 @@ set_list_content (GtkTreeView *view, char **list)
                         REMOVE_COLUMN, GTK_STOCK_REMOVE,
                         -1);
     GtkTreePath *path = gtk_tree_model_get_path (model, &iter);
-    
+
     gtk_tree_path_free (path);
   }
 }
@@ -1438,7 +1444,7 @@ init_list (struct ListExtraWidgets *widgets,
   GtkListStore *store = gtk_list_store_new (N_COLUMN,
                                             G_TYPE_STRING,
                                             G_TYPE_STRING);
-    
+
   /* gtk_tree_view_column_add_attribute (column, */
   /*                                     btncell, */
   /*                                     "stock", REMOVE_COLUMN); */
@@ -1689,7 +1695,7 @@ ol_option_show ()
       {NULL, NULL},
     };
     init_list (&lrc_path_widgets, path_buttons);
-    
+
     lrc_filename_widgets.entry = options.lrc_filename_text;
     lrc_filename_widgets.list = options.lrc_filename;
     lrc_filename_widgets.add_button = ol_gui_get_widget ("add-lrc-filename");

--- a/src/ol_osd_module.h
+++ b/src/ol_osd_module.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,10 +15,12 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_OSD_MODULE_H_
 #define _OL_OSD_MODULE_H_
+
+#include <gtk/gtkmenu.h>
 
 #include "ol_display_module.h"
 

--- a/src/ol_osd_render.h
+++ b/src/ol_osd_render.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,12 +15,13 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __OL_OSD_RENDER_H__
 #define __OL_OSD_RENDER_H__
 
-#include <gtk/gtk.h>
+#include <gdk/gdkpango.h>
+#include <gdk/gdkcairo.h>
 #include "ol_color.h"
 
 enum {
@@ -40,66 +41,66 @@ typedef struct
   int font_height;
 } OlOsdRenderContext;
 
-/** 
+/**
  * @brief Creates a new context
  * The new context should be destroyed by ol_osd_render_context_destroy
- * 
+ *
  * @return The new context
  */
 OlOsdRenderContext* ol_osd_render_context_new ();
-/** 
+/**
  * @brief Destroys an OlOsdRenderContext
- * 
+ *
  * @param context The context to be destroyed
  */
 void ol_osd_render_context_destroy (OlOsdRenderContext *context);
 
-/** 
+/**
  * @brief Sets the font name for a context
- * 
+ *
  * @param context An OlOsdRenderContext;
  * @param font_family Font name, must not be NULL
  */
 void ol_osd_render_set_font_name (OlOsdRenderContext *context,
                                   const char *font_name);
-/** 
+/**
  * @brief Gets the font name for a context
- * 
+ *
  * @param context An OlOsdRenderContext
  * @return The font name of the context, must be freed by g_free
  */
 char* ol_osd_render_get_font_name (OlOsdRenderContext *context);
 
-/** 
+/**
  * @brief Sets the outline width
- * 
+ *
  * @param context An OlOsdRenderContext
  * @param width Outline width, must be positive
  */
 void ol_osd_render_set_outline_width (OlOsdRenderContext *context,
                                       const int width);
 
-/** 
+/**
  * @brief Gets the outline width for a context
- * 
+ *
  * @param context An OlOsdRenderContext;
- * 
+ *
  * @return The outline width for the context
  */
 int ol_osd_render_get_outline_width (OlOsdRenderContext *context);
 
-/** 
+/**
  * @brief Gets the height of the font of a context
  *
  * @param context An OlOsdRenderContext
- * 
+ *
  * @return The height of the font
  */
 int ol_osd_render_get_font_height (OlOsdRenderContext *context);
 
-/** 
+/**
  * @brief Sets linear color
- * 
+ *
  * @param context An OlOsdRenderContext
  * @param index The index of the color
  * @param color The color to be set
@@ -109,9 +110,9 @@ void ol_osd_render_set_linear_color (OlOsdRenderContext *context,
                                      int index,
                                      OlColor color);
 
-/** 
+/**
  * @brief Paints text to pixmap
- * 
+ *
  * @param context The context of the renderer
  * @param canvas The GdkDrawable to be drawn
  * @param text The text to be painted
@@ -124,9 +125,9 @@ void ol_osd_render_paint_text (OlOsdRenderContext *context,
                                double x,
                                double y);
 
-/** 
+/**
  * @brief Gets the width and height of the text
- * 
+ *
  * @param context The context of the renderer, must not be NULL
  * @param text The text to be calculated, must not be NULL
  * @param width The width of the text
@@ -136,21 +137,21 @@ void ol_osd_render_get_pixel_size (OlOsdRenderContext *context,
                                    const char *text,
                                    int *width,
                                    int *height);
-/** 
+/**
  * @brief Sets text to the context
- * 
+ *
  * @param context An OlOsdRenderContext
  * @param text Text to be set
  */
 void ol_osd_render_set_text (OlOsdRenderContext* context,
                              const char *text);
 
-/** 
+/**
  * Sets the blur radius of shadow.
  *
  * If the radius is greater than 0, the outline of text will be blurred as shadow.
- * 
- * @param context 
+ *
+ * @param context
  * @param radius The blur radius in pixel, non-positive value to disable blurring.
  */
 void ol_osd_render_set_blur_radius (OlOsdRenderContext *context,

--- a/src/ol_osd_toolbar.c
+++ b/src/ol_osd_toolbar.c
@@ -32,7 +32,7 @@ struct _OlOsdToolbarPriv
   enum OlPlayerStatus status;
 };
 
-G_DEFINE_TYPE (OlOsdToolbar, ol_osd_toolbar, GTK_TYPE_ALIGNMENT);
+G_DEFINE_TYPE_WITH_PRIVATE (OlOsdToolbar, ol_osd_toolbar, GTK_TYPE_ALIGNMENT);
 
 enum {
   BTN_PLAY = 0,
@@ -231,7 +231,6 @@ ol_osd_toolbar_class_init (OlOsdToolbarClass *klass)
 {
   GtkObjectClass *gtk_class = GTK_OBJECT_CLASS (klass);
   gtk_class->destroy = ol_osd_toolbar_destroy;
-  g_type_class_add_private (klass, sizeof (OlOsdToolbarPriv));
 }
 
 static void

--- a/src/ol_osd_toolbar.h
+++ b/src/ol_osd_toolbar.h
@@ -20,7 +20,11 @@
 #ifndef _OL_OSD_TOOLBAR_H_
 #define _OL_OSD_TOOLBAR_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtkbutton.h>
+#include <gtk/gtkhbox.h>
+#include <gtk/gtkvbox.h>
+#include <gtk/gtkicontheme.h>
+#include <gtk/gtkalignment.h>
 #include "ol_player.h"
 
 #define OL_OSD_TOOLBAR(obj)                  GTK_CHECK_CAST (obj, ol_osd_toolbar_get_type (), OlOsdToolbar)

--- a/src/ol_osd_toolbar.h
+++ b/src/ol_osd_toolbar.h
@@ -25,11 +25,12 @@
 #include <gtk/gtkvbox.h>
 #include <gtk/gtkicontheme.h>
 #include <gtk/gtkalignment.h>
+#include <gtk/gtktypeutils.h>
 #include "ol_player.h"
 
-#define OL_OSD_TOOLBAR(obj)                  GTK_CHECK_CAST (obj, ol_osd_toolbar_get_type (), OlOsdToolbar)
+#define OL_OSD_TOOLBAR(obj)                  G_TYPE_CHECK_INSTANCE_CAST (obj, ol_osd_toolbar_get_type (), OlOsdToolbar)
 #define OL_OSD_TOOLBAR_CLASS(klass)          GTK_CHECK_CLASS_CAST (klass, ol_osd_toolbar_get_type (), OlOsdToolbarClass)
-#define OL_IS_OSD_TOOLBAR(obj)               GTK_CHECK_TYPE (obj, ol_osd_toolbar_get_type ())
+#define OL_IS_OSD_TOOLBAR(obj)               G_TYPE_CHECK_INSTANCE_TYPE (obj, ol_osd_toolbar_get_type ())
 #define OL_OSD_TOOLBAR_GET_CLASS(obj)        (G_TYPE_INSTANCE_GET_CLASS ((obj), ol_osd_toolbar_get_type (), OlOsdToolbarClass))
 
 typedef struct _OlOsdToolbar OlOsdToolbar;
@@ -57,7 +58,7 @@ struct _OlOsdToolbarClass
   GtkAlignmentClass parent_class;
 };
 
-GtkType ol_osd_toolbar_get_type (void);
+GType ol_osd_toolbar_get_type (void);
 
 GtkWidget *ol_osd_toolbar_new (void);
 void ol_osd_toolbar_set_player (OlOsdToolbar *toolbar, OlPlayer *player);

--- a/src/ol_osd_toolbar.h
+++ b/src/ol_osd_toolbar.h
@@ -33,6 +33,7 @@
 #define OL_OSD_TOOLBAR_GET_CLASS(obj)        (G_TYPE_INSTANCE_GET_CLASS ((obj), ol_osd_toolbar_get_type (), OlOsdToolbarClass))
 
 typedef struct _OlOsdToolbar OlOsdToolbar;
+typedef struct _OlOsdToolbarPrivate OlOsdToolbarPrivate;
 typedef struct _OlOsdToolbarClass OlOsdToolbarClass;
 
 struct _OlOsdToolbar
@@ -45,6 +46,10 @@ struct _OlOsdToolbar
   GtkButton *next_button;
   GtkButton *stop_button;
   gpointer priv; /** Private data pointer */
+};
+
+struct _OlOsdToolbarPrivate
+{
 };
 
 struct _OlOsdToolbarClass

--- a/src/ol_osd_window.c
+++ b/src/ol_osd_window.c
@@ -95,7 +95,7 @@ struct OsdLrc
   gchar *lyric;
 };
 
-G_DEFINE_TYPE(OlOsdWindow, ol_osd_window, GTK_TYPE_WINDOW)
+G_DEFINE_TYPE_WITH_PRIVATE (OlOsdWindow, ol_osd_window, GTK_TYPE_WINDOW)
 static void ol_osd_window_destroy (GtkObject *object);
 static void ol_osd_window_set_property (GObject *object, guint prop_id,
                                         const GValue *value, GParamSpec *pspec);
@@ -1661,7 +1661,6 @@ ol_osd_window_class_init (OlOsdWindowClass *klass)
                   G_TYPE_NONE,
                   0,
                   NULL);
-  g_type_class_add_private (gobject_class, sizeof (OlOsdWindowPrivate));
 }
 
 static void

--- a/src/ol_osd_window.c
+++ b/src/ol_osd_window.c
@@ -291,8 +291,8 @@ ol_osd_window_update_colormap (OlOsdWindow *osd)
 {
   ol_assert (OL_IS_OSD_WINDOW (osd));
   GtkWidget *widget = GTK_WIDGET (osd);
-  gboolean mapped = GTK_WIDGET_MAPPED (widget);
-  gboolean realized = GTK_WIDGET_REALIZED (widget);
+  gboolean mapped = gtk_widget_get_mapped (widget);
+  gboolean realized = gtk_widget_get_realized (widget);
   GdkScreen *screen = gtk_widget_get_screen (widget);
   GdkColormap* colormap = gdk_screen_get_rgba_colormap (screen);
   if (colormap == NULL)
@@ -705,7 +705,7 @@ ol_osd_window_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
   widget->allocation = *allocation;
 
   /* priv->width = allocation->width; */
-  if (GTK_WIDGET_REALIZED (widget))
+  if (gtk_widget_get_realized (widget))
   {
     gdk_window_resize (widget->window,
                        widget->allocation.width,
@@ -755,7 +755,7 @@ ol_osd_window_mouse_timer (gpointer data)
   OlOsdWindow *osd = OL_OSD_WINDOW (data);
   OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE (osd);
   GtkWidget *widget = GTK_WIDGET (osd);
-  if (GTK_WIDGET_REALIZED (osd))
+  if (gtk_widget_get_realized (widget))
   {
     gint rel_x, rel_y;
     gboolean mouse_over = FALSE;
@@ -851,7 +851,7 @@ ol_osd_window_set_locked (OlOsdWindow *osd, gboolean locked)
   if (priv->locked == locked)
     return;
   priv->locked = locked;
-  if (GTK_WIDGET_REALIZED (GTK_WIDGET (osd))) {
+  if (gtk_widget_get_realized (GTK_WIDGET (osd))) {
     ol_osd_window_set_input_shape_mask (osd, locked);
   }
   ol_osd_window_queue_reshape (osd);
@@ -864,7 +864,7 @@ ol_osd_window_update_child_size_requisition (OlOsdWindow *osd)
   ol_assert (OL_IS_OSD_WINDOW (osd));
   OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE (osd);
   GtkBin *bin = GTK_BIN (osd);
-  if (bin->child && GTK_WIDGET_VISIBLE (bin->child))
+  if (bin->child && gtk_widget_get_visible (bin->child))
   {
     gtk_widget_size_request (bin->child, &priv->child_requisition);
   }
@@ -932,7 +932,7 @@ ol_osd_window_update_child_allocation (OlOsdWindow *osd)
   GtkWidget *widget = GTK_WIDGET (osd);
   GtkBin *bin = GTK_BIN (osd);
   OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE (osd);
-  if (bin->child && GTK_WIDGET_VISIBLE (bin->child))
+  if (bin->child && gtk_widget_get_visible (bin->child))
   {
     ol_debugf ("set child allocation\n");
     GtkAllocation alloc;
@@ -1029,7 +1029,7 @@ ol_osd_window_paint_lyrics (OlOsdWindow *osd, cairo_t *cr)
   {
     alpha = 0.3;
   }
-  if (!GTK_WIDGET_REALIZED (widget))
+  if (!gtk_widget_get_realized (widget))
     gtk_widget_realize (widget);
   gint w, h;
   int width, height;
@@ -1235,7 +1235,7 @@ ol_osd_draw_lyric_surface (OlOsdWindow *osd, cairo_surface_t **surface, const ch
   if (!ol_is_string_empty (lyric) && *surface == NULL)
   {
     int w, h;
-    if (!GTK_WIDGET_REALIZED (GTK_WIDGET (osd)))
+    if (!gtk_widget_get_realized (GTK_WIDGET (osd)))
       gtk_widget_realize (GTK_WIDGET (osd));
     ol_osd_render_get_pixel_size (osd->render_context,
                                   lyric,
@@ -1258,7 +1258,7 @@ static void
 ol_osd_window_update_lyric_surface (OlOsdWindow *osd, int line)
 {
   int i;
-  if (!GTK_WIDGET_REALIZED (GTK_WIDGET (osd)))
+  if (!gtk_widget_get_realized (GTK_WIDGET (osd)))
     return;
   OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE (osd);
   /* draws the inactive surfaces */
@@ -1356,7 +1356,7 @@ ol_osd_window_reset_shape_pixmap (OlOsdWindow *osd)
 {
   /* init shape pixmap */
   ol_assert (OL_IS_OSD_WINDOW (osd));
-  if (!GTK_WIDGET_REALIZED (GTK_WIDGET (osd)))
+  if (!gtk_widget_get_realized (GTK_WIDGET (osd)))
     return;
   GtkWidget *widget = GTK_WIDGET (osd);
   OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE (osd);
@@ -1397,7 +1397,7 @@ ol_osd_window_update_shape (OlOsdWindow *osd)
   ol_assert (OL_IS_OSD_WINDOW (osd));
   GtkWidget *widget = GTK_WIDGET (osd);
   static gboolean empty_mask = TRUE;
-  if (!GTK_WIDGET_REALIZED (widget))
+  if (!gtk_widget_get_realized (widget))
     return;
   OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE (osd);
   if (priv->composited ||
@@ -1431,7 +1431,7 @@ ol_osd_window_set_input_shape_mask (OlOsdWindow *osd, gboolean disable_input)
 {
   ol_assert (OL_IS_OSD_WINDOW (osd));
   GtkWidget *widget = GTK_WIDGET (osd);
-  ol_assert (GTK_WIDGET_REALIZED (widget));
+  ol_assert (gtk_widget_get_realized (widget));
   if (disable_input)
   {
     GdkRegion *region = gdk_region_new ();
@@ -1513,7 +1513,7 @@ ol_osd_window_queue_resize (OlOsdWindow *osd)
   ol_assert (OL_IS_OSD_WINDOW (osd));
   GtkWidget *widget = GTK_WIDGET (osd);
   OlOsdWindowPrivate *priv = OL_OSD_WINDOW_GET_PRIVATE (osd);
-  if (!GTK_WIDGET_REALIZED (widget))
+  if (!gtk_widget_get_realized (widget))
     return;
   ol_osd_window_update_layout (osd);
   int h = ol_osd_window_compute_window_height (osd);
@@ -1994,8 +1994,8 @@ ol_osd_window_set_mode (OlOsdWindow *osd, enum OlOsdWindowMode mode)
   GtkWidget *widget = GTK_WIDGET (osd);
   if (mode == priv->mode)
     return;
-  gboolean realized = GTK_WIDGET_REALIZED (widget);
-  gboolean mapped = GTK_WIDGET_MAPPED (widget);
+  gboolean realized = gtk_widget_get_realized (widget);
+  gboolean mapped = gtk_widget_get_mapped (widget);
   if (mapped)
     gtk_widget_unmap (widget);
   if (realized)

--- a/src/ol_osd_window.h
+++ b/src/ol_osd_window.h
@@ -30,11 +30,12 @@
 #include <gtk/gtkwindow.h>
 #include <gtk/gtkwidget.h>
 #include <gtk/gtktypeutils.h>
+#include <gtk/gtktypeutils.h>
 #include "ol_osd_render.h"
 
-#define OL_OSD_WINDOW(obj)                  GTK_CHECK_CAST (obj, ol_osd_window_get_type (), OlOsdWindow)
+#define OL_OSD_WINDOW(obj)                  G_TYPE_CHECK_INSTANCE_CAST (obj, ol_osd_window_get_type (), OlOsdWindow)
 #define OL_OSD_WINDOW_CLASS(klass)          GTK_CHECK_CLASS_CAST (klass, ol_osd_window_get_type (), OlOsdWindowClass)
-#define OL_IS_OSD_WINDOW(obj)               GTK_CHECK_TYPE (obj, ol_osd_window_get_type ())
+#define OL_IS_OSD_WINDOW(obj)               G_TYPE_CHECK_INSTANCE_TYPE (obj, ol_osd_window_get_type ())
 #define OL_OSD_WINDOW_GET_CLASS(obj)        (G_TYPE_INSTANCE_GET_CLASS ((obj), ol_osd_window_get_type (), OlOsdWindowClass))
 #define OL_OSD_WINDOW_MAX_LINE_COUNT        2
 
@@ -76,7 +77,7 @@ struct _OlOsdWindowClass
   guint signals[OSD_SINGAL_COUNT];
 };
 
-GtkType ol_osd_window_get_type (void);
+GType ol_osd_window_get_type (void);
 
 /**
  * @brief Creates a new OSD Window.

--- a/src/ol_osd_window.h
+++ b/src/ol_osd_window.h
@@ -27,7 +27,9 @@
 #ifndef __OSD_WINDOW_H_
 #define __OSD_WINDOW_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtkwindow.h>
+#include <gtk/gtkwidget.h>
+#include <gtk/gtktypeutils.h>
 #include "ol_osd_render.h"
 
 #define OL_OSD_WINDOW(obj)                  GTK_CHECK_CAST (obj, ol_osd_window_get_type (), OlOsdWindow)

--- a/src/ol_player.c
+++ b/src/ol_player.c
@@ -142,7 +142,7 @@ static void _cancel_call (GCancellable **cancellable);
 static GVariant *ol_player_get_property (GDBusProxy *proxy,
                                          const char *name);
 
-G_DEFINE_TYPE (OlPlayer, ol_player, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE (OlPlayer, ol_player, G_TYPE_OBJECT);
 
 static void
 ol_player_class_init (OlPlayerClass *klass)
@@ -198,7 +198,6 @@ ol_player_class_init (OlPlayerClass *klass)
                   g_cclosure_marshal_VOID__VOID,
                   G_TYPE_NONE,
                   0);
-  g_type_class_add_private (klass, sizeof (OlPlayerPrivate));
 }
 
 OlPlayer *

--- a/src/ol_player_chooser.c
+++ b/src/ol_player_chooser.c
@@ -33,7 +33,7 @@ static const guint ALL_CHOOSER_INDEX = 1;
 static const guint MAX_CHOOSER_HEIGHT = 96 * 3; /* about 3 lines of apps */
 static const guint DEFAULT_APP_COLUMNS = 4;
 
-G_DEFINE_TYPE(OlPlayerChooser, ol_player_chooser, GTK_TYPE_DIALOG)
+G_DEFINE_TYPE (OlPlayerChooser, ol_player_chooser, GTK_TYPE_DIALOG)
 
 typedef struct _OlPlayerChooserPage
 {
@@ -102,7 +102,6 @@ ol_player_chooser_class_init (OlPlayerChooserClass *klass)
   ol_player_chooser_parent_class = g_type_class_peek_parent (klass);
 
   object_class->destroy = _destroy;
-  g_type_class_add_private (gobject_class, sizeof (OlPlayerChooserPrivate));
 }
 
 static void

--- a/src/ol_player_chooser.h
+++ b/src/ol_player_chooser.h
@@ -20,7 +20,24 @@
 #ifndef _OL_PLAYER_CHOOSER_H_
 #define _OL_PLAYER_CHOOSER_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtkdialog.h>
+#include <gtk/gtkwidget.h>
+#include <gtk/gtktogglebutton.h>
+#include <gtk/gtkradiobutton.h>
+#include <gtk/gtkscrolledwindow.h>
+#include <gtk/gtkentry.h>
+#include <gtk/gtklabel.h>
+#include <gtk/gtkimage.h>
+#include <gtk/gtkobject.h>
+#include <gtk/gtkbutton.h>
+#include <gtk/gtkentrycompletion.h>
+#include <gtk/gtkbox.h>
+#include <gtk/gtkhbox.h>
+#include <gtk/gtkvbox.h>
+#include <gtk/gtkliststore.h>
+#include <gtk/gtkstock.h>
+#include <gtk/gtkvseparator.h>
+
 #define OL_PLAYER_CHOOSER(obj)                  GTK_CHECK_CAST (obj, ol_player_chooser_get_type (), OlPlayerChooser)
 #define OL_PLAYER_CHOOSER_CLASS(klass)          GTK_CHECK_CLASS_CAST (klass, ol_player_chooser_get_type (), OlPlayerChooserClass)
 #define OL_IS_PLAYER_CHOOSER(obj)               GTK_CHECK_TYPE (obj, ol_player_chooser_get_type ())

--- a/src/ol_player_chooser.h
+++ b/src/ol_player_chooser.h
@@ -37,10 +37,11 @@
 #include <gtk/gtkliststore.h>
 #include <gtk/gtkstock.h>
 #include <gtk/gtkvseparator.h>
+#include <gtk/gtktypeutils.h>
 
-#define OL_PLAYER_CHOOSER(obj)                  GTK_CHECK_CAST (obj, ol_player_chooser_get_type (), OlPlayerChooser)
+#define OL_PLAYER_CHOOSER(obj)                  G_TYPE_CHECK_INSTANCE_CAST (obj, ol_player_chooser_get_type (), OlPlayerChooser)
 #define OL_PLAYER_CHOOSER_CLASS(klass)          GTK_CHECK_CLASS_CAST (klass, ol_player_chooser_get_type (), OlPlayerChooserClass)
-#define OL_IS_PLAYER_CHOOSER(obj)               GTK_CHECK_TYPE (obj, ol_player_chooser_get_type ())
+#define OL_IS_PLAYER_CHOOSER(obj)               G_TYPE_CHECK_INSTANCE_TYPE (obj, ol_player_chooser_get_type ())
 #define OL_PLAYER_CHOOSER_GET_CLASS(obj)        (G_TYPE_INSTANCE_GET_CLASS ((obj), ol_player_chooser_get_type (), OlPlayerChooserClass))
 
 enum OlPlayerChooserResponse {
@@ -67,7 +68,7 @@ struct _OlPlayerChooserClass
   GtkDialogClass parent_class;
 };
 
-GtkType ol_player_chooser_get_type (void);
+GType ol_player_chooser_get_type (void);
 
 /**
  * Creates a new player chooser window.

--- a/src/ol_scroll_module.h
+++ b/src/ol_scroll_module.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2010  Sarlmol Apple <sarlmolapple@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,10 +15,15 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_SCROLL_MODULE_H_
 #define _OL_SCROLL_MODULE_H_
+
+#include <gtk/gtkicontheme.h>
+#include <gtk/gtkmenu.h>
+#include <gtk/gtkmain.h>
+#include <gtk/gtkhbox.h>
 
 #include "ol_display_module.h"
 

--- a/src/ol_scroll_window.c
+++ b/src/ol_scroll_window.c
@@ -429,7 +429,7 @@ _calc_lrc_ypos (OlScrollWindow *scroll, double percentage)
   ol_assert_ret (OL_IS_SCROLL_WINDOW (scroll), -1);
   GtkWidget *widget = GTK_WIDGET (scroll);
   OlScrollWindowPrivate *priv = OL_SCROLL_WINDOW_GET_PRIVATE (scroll);
-  if (!GTK_WIDGET_REALIZED (widget))
+  if (!gtk_widget_get_realized (widget))
     return -1;
   gint line_height;
   line_height = ol_scroll_window_get_font_height (scroll) + priv->line_margin;
@@ -492,7 +492,7 @@ _paint_lyrics (OlScrollWindow *scroll, cairo_t *cr)
 {
   ol_assert (OL_IS_SCROLL_WINDOW (scroll));
   GtkWidget *widget = GTK_WIDGET (scroll);
-  ol_assert (GTK_WIDGET_REALIZED (widget));
+  ol_assert (gtk_widget_get_realized (widget));
   OlScrollWindowPrivate *priv = OL_SCROLL_WINDOW_GET_PRIVATE (scroll);
   int line_height = ol_scroll_window_get_font_height (scroll) + priv->line_margin;
   int count = ol_scroll_window_compute_line_count (scroll);

--- a/src/ol_scroll_window.c
+++ b/src/ol_scroll_window.c
@@ -123,7 +123,7 @@ static void ol_scroll_window_seek (OlScrollWindow *scroll,
 static void ol_scroll_window_end_seek (OlScrollWindow *scroll);
 static void ol_scroll_window_update_tooltip (OlScrollWindow *scroll);
 
-G_DEFINE_TYPE (OlScrollWindow, ol_scroll_window, GTK_TYPE_WINDOW);
+G_DEFINE_TYPE_WITH_PRIVATE (OlScrollWindow, ol_scroll_window, GTK_TYPE_WINDOW);
 
 
 GtkWidget*
@@ -244,8 +244,6 @@ ol_scroll_window_class_init (OlScrollWindowClass *klass)
                   2,
                   G_TYPE_UINT,
                   G_TYPE_DOUBLE);
-  /*add private variables into OlScrollWindow*/
-  g_type_class_add_private (gobject_class, sizeof (OlScrollWindowPrivate));
 }
 
 void

--- a/src/ol_scroll_window.h
+++ b/src/ol_scroll_window.h
@@ -21,7 +21,9 @@
 #ifndef __SCROLL_WINDOW_H_
 #define __SCROLL_WINDOW_H_
 
-#include <gtk/gtk.h>
+#include <gtk/gtkwindow.h>
+#include <gtk/gtkwidget.h>
+#include <gtk/gtkalignment.h>
 #include <ol_debug.h>
 #include "ol_color.h"
 

--- a/src/ol_scroll_window.h
+++ b/src/ol_scroll_window.h
@@ -24,12 +24,13 @@
 #include <gtk/gtkwindow.h>
 #include <gtk/gtkwidget.h>
 #include <gtk/gtkalignment.h>
+#include <gtk/gtktypeutils.h>
 #include <ol_debug.h>
 #include "ol_color.h"
 
-#define OL_SCROLL_WINDOW(obj)                   GTK_CHECK_CAST (obj, ol_scroll_window_get_type (), OlScrollWindow)
+#define OL_SCROLL_WINDOW(obj)                   G_TYPE_CHECK_INSTANCE_CAST (obj, ol_scroll_window_get_type (), OlScrollWindow)
 #define OL_SCROLL_WINDOW_CLASS(klass)           GTK_CHECK_CLASS_CAST (klass, ol_scroll_window_get_type (), OlScrollWindowClass)
-#define OL_IS_SCROLL_WINDOW(obj)                GTK_CHECK_TYPE (obj, ol_scroll_window_get_type ())
+#define OL_IS_SCROLL_WINDOW(obj)                G_TYPE_CHECK_INSTANCE_TYPE (obj, ol_scroll_window_get_type ())
 #define OL_SCROLL_WINDOW_GET_CLASS(obj)         (G_TYPE_INSTANCE_GET_CLASS ((obj), ol_scroll_window_get_type (), OlScrollWindowClass))
 
 typedef struct _OlScrollWindow                  OlScrollWindow;
@@ -56,7 +57,7 @@ struct _OlScrollWindowClass
   GtkWindowClass parent_class;
 };
 
-GtkType ol_scroll_window_get_type (void);
+GType ol_scroll_window_get_type (void);
 
 /**
  * @brief create a new Scroll Window.

--- a/src/ol_search_dialog.c
+++ b/src/ol_search_dialog.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "ol_search_dialog.h"
 #include "ol_gui.h"
@@ -47,13 +47,13 @@ struct
 static OlLyricSourceSearchTask *search_task = NULL;
 static OlMetadata *global_metadata = NULL;
 
-gboolean ol_search_dialog_search_click (GtkWidget *widget, 
+gboolean ol_search_dialog_search_click (GtkWidget *widget,
                                         gpointer data);
-gboolean ol_search_dialog_download_click (GtkWidget *widget, 
+gboolean ol_search_dialog_download_click (GtkWidget *widget,
                                           gpointer data);
 gboolean ol_search_dialog_cancel_click (GtkWidget *widget,
                                         gpointer data);
-static void internal_select_changed (GtkTreeSelection *selection, 
+static void internal_select_changed (GtkTreeSelection *selection,
                                      gpointer data);
 static gboolean internal_init ();
 static void ol_search_dialog_search_complete_cb (OlLyricSourceSearchTask *task,
@@ -75,13 +75,13 @@ internal_select_changed (GtkTreeSelection *selection, gpointer data)
 {
   if (widgets.download != NULL)
     gtk_widget_set_sensitive (GTK_WIDGET (widgets.download),
-                              gtk_tree_selection_get_selected (selection, 
-                                                               NULL, 
+                              gtk_tree_selection_get_selected (selection,
+                                                               NULL,
                                                                NULL));
 }
 
 gboolean
-ol_search_dialog_download_click (GtkWidget *widget, 
+ol_search_dialog_download_click (GtkWidget *widget,
                                  gpointer data)
 {
   ol_log_func ();
@@ -117,11 +117,11 @@ ol_search_dialog_search_click (GtkWidget *widget,
 {
   ol_log_func ();
   OlMetadata *metadata = ol_metadata_new ();
-  ol_metadata_copy (metadata, 
+  ol_metadata_copy (metadata,
                     ol_app_get_current_music ());
   if (widgets.title != NULL)
     ol_metadata_set_title (metadata,
-                           gtk_entry_get_text (widgets.title));  
+                           gtk_entry_get_text (widgets.title));
   if (widgets.artist != NULL)
     ol_metadata_set_artist (metadata,
                             gtk_entry_get_text (widgets.artist));
@@ -262,7 +262,7 @@ internal_init ()
     widgets.list = GTK_TREE_VIEW (ol_gui_get_widget ("search-candidates-list"));
     widgets.msg = GTK_LABEL (ol_gui_get_widget ("search-msg"));
     widgets.download = ol_gui_get_widget ("search-download");
-    ol_lyric_candidate_list_init (widgets.list, 
+    ol_lyric_candidate_list_init (widgets.list,
                                 G_CALLBACK (internal_select_changed));
     widgets.engine = ol_gui_get_widget ("search-engine");
     ol_lyric_source_list_init (GTK_TREE_VIEW (widgets.engine));
@@ -275,7 +275,7 @@ ol_search_dialog_show ()
 {
   if (!internal_init ())
     return;
-  if (GTK_WIDGET_VISIBLE (widgets.window))
+  if (gtk_widget_get_visible (widgets.window))
     return;
   ol_lyric_candidate_list_clear (widgets.list);
 
@@ -284,18 +284,18 @@ ol_search_dialog_show ()
   ol_metadata_copy (global_metadata, ol_app_get_current_music ());
 
 /* fill with real title and artist
-  gtk_entry_set_text (widgets.title, 
+  gtk_entry_set_text (widgets.title,
                       ol_metadata_get_title (global_metadata));
   gtk_entry_set_text (widgets.artist,
                       ol_metadata_get_artist (global_metadata));
 */
 //
-  gtk_entry_set_text (widgets.title, 
+  gtk_entry_set_text (widgets.title,
                       ol_metadata_get_search_title (global_metadata));
   gtk_entry_set_text (widgets.artist,
                       ol_metadata_get_search_artist (global_metadata));
 //
- 
+
   gtk_widget_set_sensitive (widgets.download,
                             FALSE);
   gtk_label_set_text (widgets.msg, "");

--- a/src/ol_search_dialog.h
+++ b/src/ol_search_dialog.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,10 +15,13 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef _OL_SEARCH_DIALOG_H_
 #define _OL_SEARCH_DIALOG_H_
+
+#include <gtk/gtkwidget.h>
+#include <gtk/gtklabel.h>
 
 void ol_search_dialog_show ();
 

--- a/src/ol_stock.c
+++ b/src/ol_stock.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,9 +15,9 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <gtk/gtk.h>
+#include <gtk/gtkiconfactory.h>
 #include "ol_stock.h"
 
 
@@ -34,7 +34,7 @@ const char *ICON_LIST[] = {
   OL_STOCK_SCROLL_CLOSE,
 };
 
-void 
+void
 ol_stock_init ()
 {
   if (icon_factory == NULL)
@@ -45,15 +45,14 @@ ol_stock_init ()
     {
       GtkIconSet *icon_set = gtk_icon_set_new ();
       GtkIconSource *icon_source = gtk_icon_source_new ();
-      gtk_icon_source_set_icon_name (icon_source, 
+      gtk_icon_source_set_icon_name (icon_source,
                                      ICON_LIST[i]);
       gtk_icon_set_add_source (icon_set, icon_source);
       gtk_icon_source_free (icon_source);
-      gtk_icon_factory_add (icon_factory, 
-                            ICON_LIST[i], 
+      gtk_icon_factory_add (icon_factory,
+                            ICON_LIST[i],
                             icon_set);
     }
     gtk_icon_factory_add_default (icon_factory);
   }
 }
-

--- a/src/ol_trayicon.c
+++ b/src/ol_trayicon.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2011  Tiger Soldier <tigersoldier@gmail.com>
  *
  * This file is part of OSD Lyrics.
- * 
+ *
  * OSD Lyrics is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>. 
+ * along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "config.h"
 #if HAVE_APP_INDICATOR
@@ -29,6 +29,8 @@
 #include "ol_player.h"
 #include "ol_config_proxy.h"
 #include "ol_debug.h"
+#include <gtk/gtkstatusicon.h>
+#include <gtk/gtktooltip.h>
 
 #if HAVE_APP_INDICATOR
 static AppIndicator *indicator = NULL;
@@ -97,7 +99,7 @@ internal_query_tooltip (GtkStatusIcon *status_icon,
     }
     gtk_tooltip_set_markup (tooltip, markup);
     g_free (markup);
-    
+
     OlPlayer *player = ol_app_get_player ();
     const char *icon_path = ol_player_get_icon_path (player);
     GdkPixbuf *icon = NULL;
@@ -113,7 +115,7 @@ internal_query_tooltip (GtkStatusIcon *status_icon,
   return TRUE;
 }
 
-static void 
+static void
 popup (GtkStatusIcon *status_icon,
        guint button,
        guint activate_time,
@@ -201,5 +203,5 @@ ol_trayicon_status_changed (enum OlPlayerStatus status)
 #else
   /* Do nothing */
 #endif
-  
+
 }


### PR DESCRIPTION
The purpose of this PR is to get the GTK warnings out of the way to prepare the way for a migration to GTK3.
After this PR is applied, the only deprecation warnings left are those coming from GLib which complains that GTK2 uses deprecated methods and classes.. can't really do much about Glib warnings other than lowering the GLib version.