### PR TITLE
Fixes for saved UI position (OSD + scroll module)

### DIFF
--- a/src/ol_config_property.h
+++ b/src/ol_config_property.h
@@ -125,6 +125,8 @@ static const OlConfigIntValue config_int[] = {
   {"Download/proxy-port", 1, 65535, 7070},
   {"ScrollMode/width", 1, 10000, 500},
   {"ScrollMode/height", 1, 10000, 400},
+  {"ScrollMode/x", 0, 10000, 0},
+  {"ScrollMode/y", 0, 10000, 0},
 };
 
 static const OlConfigDoubleValue config_double[] = {

--- a/src/ol_osd_module.c
+++ b/src/ol_osd_module.c
@@ -269,14 +269,9 @@ _visible_changed_cb (OlConfigProxy *config,
                      OlOsdModule *osd)
 {
   gboolean visible = ol_config_proxy_get_bool (config, key);
-  if (visible)
-  {
-    gtk_widget_show (GTK_WIDGET (osd->window));
-  }
-  else
-  {
-    gtk_widget_hide (GTK_WIDGET (osd->window));
-  }
+  gtk_widget_set_visible (GTK_WIDGET (osd->window), visible);
+  if (osd->toolbar != NULL)
+    ol_osd_toolbar_set_window_visibility(osd->toolbar, visible);
 }
 
 static void

--- a/src/ol_osd_toolbar.c
+++ b/src/ol_osd_toolbar.c
@@ -30,6 +30,7 @@ struct _OlOsdToolbarPriv
 {
   OlPlayer *player;
   enum OlPlayerStatus status;
+  gboolean window_visible;
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (OlOsdToolbar, ol_osd_toolbar, GTK_TYPE_ALIGNMENT);
@@ -202,6 +203,9 @@ _update_status (OlOsdToolbar *toolbar)
 {
   ol_log_func ();
   OlOsdToolbarPriv *priv = OL_OSD_TOOLBAR_GET_PRIVATE (toolbar);
+  if (!priv->window_visible)
+    return;
+
   enum OlPlayerStatus status;
   if (priv->player)
     status = ol_player_get_status (priv->player);
@@ -223,7 +227,6 @@ _update_status (OlOsdToolbar *toolbar)
     gtk_widget_show (GTK_WIDGET (toolbar->play_button));
     break;
   }
-  gtk_widget_queue_draw (GTK_WIDGET (toolbar));
 }
 
 static void
@@ -254,6 +257,7 @@ ol_osd_toolbar_init (OlOsdToolbar *toolbar)
     toolbar->next_button = _add_button (toolbar, &btn_spec[BTN_NEXT]);
 
     priv->player = NULL;
+    priv->window_visible = FALSE;
     _update_status (toolbar);
     _update_caps (toolbar);
   }
@@ -323,4 +327,15 @@ ol_osd_toolbar_set_player (OlOsdToolbar *toolbar,
   priv->player = player;
   _update_caps (toolbar);
   _update_status (toolbar);
+}
+
+void ol_osd_toolbar_set_window_visibility(OlOsdToolbar *toolbar,
+                                          gboolean window_visible)
+{
+  ol_assert (OL_IS_OSD_TOOLBAR (toolbar));
+  OlOsdToolbarPriv *priv = OL_OSD_TOOLBAR_GET_PRIVATE (toolbar);
+
+  priv->window_visible = window_visible;
+  if (window_visible)
+    _update_status(toolbar);
 }

--- a/src/ol_osd_toolbar.h
+++ b/src/ol_osd_toolbar.h
@@ -64,4 +64,7 @@ GtkWidget *ol_osd_toolbar_new (void);
 void ol_osd_toolbar_set_player (OlOsdToolbar *toolbar, OlPlayer *player);
 void ol_osd_toolbar_set_status (OlOsdToolbar *toolbar, enum OlPlayerStatus status);
 
+void ol_osd_toolbar_set_window_visibility(OlOsdToolbar *toolbar,
+                                          gboolean window_visible);
+
 #endif /* _OL_OSD_TOOLBAR_H_ */

--- a/src/ol_scroll_module.c
+++ b/src/ol_scroll_module.c
@@ -118,6 +118,9 @@ static void _font_changed_cb (OlConfigProxy *config,
 static void _size_changed_cb (OlConfigProxy *config,
                               const char *key,
                               OlScrollModule *module);
+static void _pos_changed_cb (OlConfigProxy *config,
+                             const char *key,
+                             OlScrollModule *module);
 static void _active_color_changed_cb (OlConfigProxy *config,
                                       const char *key,
                                       OlScrollModule *module);
@@ -137,6 +140,8 @@ static void _scroll_mode_changed_cb (OlConfigProxy *config,
 static struct _ConfigMapping _config_mapping[] = {
   { "ScrollMode/width", _size_changed_cb },
   { "ScrollMode/height", _size_changed_cb },
+  { "ScrollMode/x", _pos_changed_cb },
+  { "ScrollMode/y", _pos_changed_cb },
   { "ScrollMode/font-name", _font_changed_cb },
   { "ScrollMode/active-lrc-color", _active_color_changed_cb },
   { "ScrollMode/inactive-lrc-color", _inactive_color_changed_cb },
@@ -193,11 +198,14 @@ _window_configure_cb (GtkWidget *widget,
   if (_config_is_setting)
     return FALSE;
   _config_is_setting = TRUE;
-  gint width, height;
+  gint width, height, x, y;
   OlConfigProxy *config = ol_config_proxy_get_instance ();
   gtk_window_get_size (GTK_WINDOW (widget), &width, &height);
+  gtk_window_get_position (GTK_WINDOW (widget), &x, &y);
   ol_config_proxy_set_int (config, "ScrollMode/width", width);
   ol_config_proxy_set_int (config, "ScrollMode/height", height);
+  ol_config_proxy_set_int (config, "ScrollMode/x", x);
+  ol_config_proxy_set_int (config, "ScrollMode/y", y);
   _config_is_setting = FALSE;
   return FALSE;
 }
@@ -261,6 +269,16 @@ _size_changed_cb (OlConfigProxy *config,
   gint width = ol_config_proxy_get_int (config, "ScrollMode/width");
   gint height = ol_config_proxy_get_int (config, "ScrollMode/height");
   gtk_window_resize (GTK_WINDOW (module->scroll), width, height);
+}
+
+static void
+_pos_changed_cb (OlConfigProxy *config,
+                 const char *key,
+                 OlScrollModule *module)
+{
+  gint x = ol_config_proxy_get_int (config, "ScrollMode/x");
+  gint y = ol_config_proxy_get_int (config, "ScrollMode/y");
+  gtk_window_move (GTK_WINDOW (module->scroll), x, y);
 }
 
 static void


### PR DESCRIPTION
After almost exactly 4 years, finally creating a PR for this couple of patches :D Each solves a bug with restoring the position of a UI element (OSD and scroll module).