### PR TITLE
configure: use git describe for version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       
       - name: Install dependencies
         run: sudo apt-get install dh-python intltool lib{dbus-glib-1,gtk2.0,notify,x11}-dev python3{,-dbus,-future,-gi}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install dh-python intltool lib{dbus-glib-1,gtk2.0,notify,x11}-dev python3{,-dbus,-future,-gi}
 
+      - name: Version
+        run: ./check-version.sh
+
       - name: Autogen
         run: ./autogen.sh
 

--- a/check-version.sh
+++ b/check-version.sh
@@ -4,10 +4,11 @@ set -e
 
 DIR=`dirname $0`
 GIT="${GIT:-git}"
+OL_VERSION="${GIT:-0.5.11}"
 
 if test -d '.git' && command -v "$GIT" &> /dev/null; then
 	"$GIT" describe --always --tags
 else
-	echo 0.5.11
+	echo "$OL_VERSION"
 fi
 

--- a/check-version.sh
+++ b/check-version.sh
@@ -7,8 +7,7 @@ GIT="${GIT:-git}"
 OL_VERSION="${OL_VERSION:-0.5.11}"
 
 if test -d '.git' && command -v "$GIT" &> /dev/null; then
-	#"$GIT" describe --always --tags
-	echo "$OL_VERSION"
+	"$GIT" describe --always --tags
 else
 	echo "$OL_VERSION"
 fi

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -e
+
+DIR=`dirname $0`
+GIT="${GIT:-git}"
+
+if test -d '.git' && command -v "$GIT" &> /dev/null; then
+	"$GIT" describe --always --tags
+else
+	echo 0.5.11
+fi
+

--- a/check-version.sh
+++ b/check-version.sh
@@ -4,10 +4,11 @@ set -e
 
 DIR=`dirname $0`
 GIT="${GIT:-git}"
-OL_VERSION="${GIT:-0.5.11}"
+OL_VERSION="${OL_VERSION:-0.5.11}"
 
 if test -d '.git' && command -v "$GIT" &> /dev/null; then
-	"$GIT" describe --always --tags
+	#"$GIT" describe --always --tags
+	echo "$OL_VERSION"
 else
 	echo "$OL_VERSION"
 fi

--- a/check-version.sh
+++ b/check-version.sh
@@ -7,8 +7,8 @@ GIT="${GIT:-git}"
 OL_VERSION="${OL_VERSION:-0.5.11}"
 
 if test -d '.git' && command -v "$GIT" &> /dev/null; then
-	"$GIT" describe --always --tags
+	exec "$GIT" describe --always --tags
 else
-	echo "$OL_VERSION"
+	exec echo "$OL_VERSION"
 fi
 

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,9 +1,15 @@
-#!/usr/bin/env sh
+#h!/usr/bin/env sh
 
 GIT="${GIT:-git}"
 OL_VERSION="${OL_VERSION:-0.5.11}"
 
-if [ "$("$GIT" rev-parse --show-prefix 2>/dev/null)" ] ||
-   ! "$GIT" describe --always --tags 2>/dev/null; then
-	echo "$OL_VERSION"
+if [ ! "$("$GIT" rev-parse --show-prefix 2>/dev/null)" ]; then
+  _GIT_VERSION="$("$GIT" describe --always --tags 2>/dev/null)"
+  if [ "$_GIT_VERSION" ]; then
+    echo "$_GIT_VERSION"
+  else
+    echo "$OL_VERSION"
+  fi
+else
+  echo "$OL_VERSION"
 fi

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 
-DIR=`dirname $0`
 GIT="${GIT:-git}"
 OL_VERSION="${OL_VERSION:-0.5.11}"
 
-if ! "$GIT" describe --always --tags 2>/dev/null; then
+if [ "$("$GIT" rev-parse --show-prefix 2>/dev/null)" ] ||
+   ! "$GIT" describe --always --tags 2>/dev/null; then
 	echo "$OL_VERSION"
 fi

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,14 +1,9 @@
 #!/usr/bin/env sh
 
-set -e
-
 DIR=`dirname $0`
 GIT="${GIT:-git}"
 OL_VERSION="${OL_VERSION:-0.5.11}"
 
-if test -d '.git' && command -v "$GIT" &> /dev/null; then
-	exec "$GIT" describe --always --tags
-else
-	exec echo "$OL_VERSION"
+if ! "$GIT" describe --always --tags 2>/dev/null; then
+	echo "$OL_VERSION"
 fi
-

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,6 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
-m4_define([OL_VERSION], [m4_esyscmd([./check-version.sh])])
-AC_INIT([osdlyrics], [OL_VERSION], [https://github.com/osdlyrics/osdlyrics/issues])
+AC_INIT([osdlyrics], m4_esyscmd_s([./check-version.sh]), [https://github.com/osdlyrics/osdlyrics/issues])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,6 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
-m4_define([OL_MAJOR_VER], [0])
-m4_define([OL_MINOR_VER], [5])
-m4_define([OL_MICRO_VER], [10])
-m4_define([OL_BUILD], [-git])
-m4_define(OL_BUILD_VER,
-          m4_esyscmd_s([if test 'x]OL_BUILD[' = 'x-git'; then (git log -1 --format=format:%ad --date=short 2>/dev/null || date -u +%Y%m%d) | sed 's/-//g'; fi]))
-
-m4_define([OL_VERSION], [OL_MAJOR_VER.OL_MINOR_VER.OL_MICRO_VER[]OL_BUILD[]OL_BUILD_VER])
+m4_define([OL_VERSION], [m4_esyscmd_s([./check-version.sh])])
 AC_INIT([osdlyrics], [OL_VERSION], [https://github.com/osdlyrics/osdlyrics/issues])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,13 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
-m4_define([OL_VERSION], [m4_esyscmd_s([./check-version.sh])])
+m4_define([OL_MAJOR_VER], [0])
+m4_define([OL_MINOR_VER], [5])
+m4_define([OL_MICRO_VER], [10])
+m4_define([OL_BUILD], [-git])
+m4_define(OL_BUILD_VER,
+          m4_esyscmd_s([if test 'x]OL_BUILD[' = 'x-git'; then (git log -1 --format=format:%ad --date=short 2>/dev/null || date -u +%Y%m%d) | sed 's/-//g'; fi]))
+
+m4_define([OL_VERSION], [OL_MAJOR_VER.OL_MINOR_VER.OL_MICRO_VER[]OL_BUILD[]OL_BUILD_VER])
 AC_INIT([osdlyrics], [OL_VERSION], [https://github.com/osdlyrics/osdlyrics/issues])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
-AC_INIT([osdlyrics], m4_esyscmd_s([./check-version.sh]), [https://github.com/osdlyrics/osdlyrics/issues])
+AC_INIT([osdlyrics], [m4_esyscmd_s([./check-version.sh])], [https://github.com/osdlyrics/osdlyrics/issues])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
-AC_INIT([osdlyrics], [m4_esyscmd_s([./check-version.sh])], [https://github.com/osdlyrics/osdlyrics/issues])
+m4_define(OL_VERSION, m4_esyscmd_s([./check-version.sh]))
+AC_INIT([osdlyrics], [OL_VERSION], [https://github.com/osdlyrics/osdlyrics/issues])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,6 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
-m4_define([OL_MAJOR_VER], [0])
-m4_define([OL_MINOR_VER], [5])
-m4_define([OL_MICRO_VER], [10])
-m4_define([OL_BUILD], [-git])
-m4_define(OL_BUILD_VER,
-          m4_esyscmd_s([if test 'x]OL_BUILD[' = 'x-git'; then (git log -1 --format=format:%ad --date=short 2>/dev/null || date -u +%Y%m%d) | sed 's/-//g'; fi]))
-
-m4_define([OL_VERSION], [OL_MAJOR_VER.OL_MINOR_VER.OL_MICRO_VER[]OL_BUILD[]OL_BUILD_VER])
+m4_define([OL_VERSION], [m4_esyscmd([./check-version.sh])])
 AC_INIT([osdlyrics], [OL_VERSION], [https://github.com/osdlyrics/osdlyrics/issues])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,6 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
-m4_define(OL_VERSION, m4_esyscmd_s([./check-version.sh]))
-AC_INIT([osdlyrics], [OL_VERSION], [https://github.com/osdlyrics/osdlyrics/issues])
+AC_INIT([osdlyrics], [m4_esyscmd_s([./check-version.sh])], [https://github.com/osdlyrics/osdlyrics/issues])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 


### PR DESCRIPTION
This simplifies the formulation of `OL_VERSION` and should fix #110 (Cc @bmwiedemann).

By "simplify", I mean reducing it to two easy scenarios:
- We either are building from a git clone of the repo, where we have the `.git` directory and `git` in `PATH`, so we can use `git describe` to fetch something useful as `0.5.10-1.35bf828`;
- Or, we are building from a release/tag's tarball and have a trustful hard-coded version as `0.5.11`.

PS: I've tested that condition line in GNU's bash and Busybox's ash.