### PR TITLE
Rename config entry ".visible" -> "OSD/visible"

### DIFF
--- a/src/ol_commands.c
+++ b/src/ol_commands.c
@@ -34,6 +34,6 @@ ol_show_hide ()
 {
   OlConfigProxy *config = ol_config_proxy_get_instance ();
   ol_assert (config != NULL);
-  ol_config_proxy_set_bool (config, "General/visible",
-                            !ol_config_proxy_get_bool (config, "General/visible"));
+  ol_config_proxy_set_bool (config, "OSD/visible",
+                            !ol_config_proxy_get_bool (config, "OSD/visible"));
 }

--- a/src/ol_config_property.h
+++ b/src/ol_config_property.h
@@ -108,7 +108,7 @@ static const OlConfigStrListValue config_str_list[] = {
 
 static const OlConfigBoolValue config_bool[] = {
   {"OSD/locked", TRUE},
-  {".visible", TRUE},
+  {"OSD/visible", TRUE},
   {"OSD/translucent-on-mouse-over", TRUE},
   {"Download/download-first-lyric", FALSE},
   {"General/display-mode-osd", TRUE},

--- a/src/ol_menu.c
+++ b/src/ol_menu.c
@@ -219,7 +219,7 @@ ol_menu_hide (GtkWidget *widget, gpointer data)
   OlConfigProxy *config = ol_config_proxy_get_instance ();
   ol_assert (config != NULL);
   gboolean hide = gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (widget));
-  ol_config_proxy_set_bool (config, ".visible", !hide);
+  ol_config_proxy_set_bool (config, "OSD/visible", !hide);
 }
 
 void
@@ -342,7 +342,7 @@ ol_menu_init ()
   
   gtk_widget_show_all (popup_menu);
   _locked_changed_cb (config, "OSD/locked", NULL);
-  _visible_changed_cb (config, ".visible", NULL);
+  _visible_changed_cb (config, "OSD/visible", NULL);
   _display_mode_osd_changed_cb (config, "General/display-mode-osd", NULL);
   _display_mode_scroll_changed_cb (config, "General/display-mode-scroll", NULL);
   g_signal_connect (config,
@@ -350,7 +350,7 @@ ol_menu_init ()
                     G_CALLBACK (_locked_changed_cb),
                     NULL);
   g_signal_connect (config,
-                    "changed::.visible",
+                    "changed::OSD/visible",
                     G_CALLBACK (_visible_changed_cb),
                     NULL);
   g_signal_connect (config,

--- a/src/ol_osd_module.c
+++ b/src/ol_osd_module.c
@@ -172,7 +172,7 @@ static void _blur_changed_cb (OlConfigProxy *config,
                               OlOsdModule *osd);
 
 static struct _ConfigMapping _config_mapping[] = {
-  { ".visible", _visible_changed_cb },
+  { "OSD/visible", _visible_changed_cb },
   { "OSD/width", _width_changed_cb },
   { "OSD/osd-window-mode", _mode_changed_cb },
   { "OSD/locked", _locked_changed_cb },

--- a/src/ol_trayicon.c
+++ b/src/ol_trayicon.c
@@ -55,8 +55,8 @@ activate (GtkStatusIcon* status_icon,
           gpointer user_data)
 {
   OlConfigProxy *config = ol_config_proxy_get_instance ();
-  ol_config_proxy_set_bool (config, ".visible",
-                            !ol_config_proxy_get_bool (config, ".visible"));
+  ol_config_proxy_set_bool (config, "OSD/visible",
+                            !ol_config_proxy_get_bool (config, "OSD/visible"));
 }
 
 static gboolean


### PR DESCRIPTION
The config entry that controls the visibility of the OSD was originally
named "OSD/visible" (before commit 638c86b60d92 ("implement default
value setting")). Through some accident of history, it ended up being
called either ".visible" or "General/visible", resulting in the keyboard
shortcut to toggle the visibility doing nothing.

The motivation for using ".visible" was to make the option
non-persistant (see src/ol_trayicon.c). However this has the potentially
undesirable side effect of making it impossible to set it through DBus.
"General/visible" seems to be a strange name as well, as it only
toggles the visibility of the OSD.

All things considered, it feels like reverting to the original name is
the most sensible thing to do.

Fixes #49