### PR TITLE
ol_scroll_module: do not allow the close button to grab focus

### DIFF
--- a/src/ol_scroll_module.c
+++ b/src/ol_scroll_module.c
@@ -378,6 +378,7 @@ _toolbar_new (OlScrollModule *module)
                      GTK_WIDGET (button));
   gtk_icon_info_free (info);
 
+  gtk_widget_set_can_focus(GTK_WIDGET (button), FALSE);
   gtk_widget_show_all (toolbar);
   return toolbar;
 }


### PR DESCRIPTION
For a while I could not explain why pressing Space or Enter in the
scroll window causes OSD Lyrics to exit. It turned out this is because
the close button always gets the focus when the window is active, causing
Space/Enter to "click" it.

This is clearly not desirable, so make sure that the close button cannot
grab the focus (i.e. it can only be activated by actually clicking on it).