### PR TITLE
ol_osd: hide the OSD only while the player is stopped

### DIFF
--- a/data/dialogs.glade
+++ b/data/dialogs.glade
@@ -2013,8 +2013,8 @@ SimplyZhao &lt;simplyzhao@gmail.com&gt;</property>
     <child>
       <object class="GtkCheckMenuItem" id="menu-hide">
         <property name="visible">True</property>
-        <property name="tooltip_text" translatable="yes">Hide the OSD Window</property>
-        <property name="label" translatable="yes">_Hide OSD</property>
+        <property name="tooltip_text" translatable="yes">Hide the OSD window when the player is stopped</property>
+        <property name="label" translatable="yes">_Hide OSD when stopped</property>
         <property name="use_underline">True</property>
         <signal name="activate" handler="ol_menu_hide"/>
       </object>

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -301,7 +301,7 @@ The interface is ``org.osdlyrics.config``.
 
 The name of configure options
 -----------------------------
-All the name used in configure options MUST be in the format of "group_name/options_name". For example, the visibility of OSD Window should be configured in "OSD/visible".
+All the name used in configure options MUST be in the format of "group_name/options_name". For example, the visibility of the OSD Window when the player is stopped should be configured in "OSD/visible_when_stopped".
 
 Methods
 -------

--- a/src/ol_commands.c
+++ b/src/ol_commands.c
@@ -30,10 +30,10 @@ ol_osd_lock_unlock ()
 }
 
 void
-ol_show_hide ()
+ol_osd_switch_display ()
 {
   OlConfigProxy *config = ol_config_proxy_get_instance ();
   ol_assert (config != NULL);
-  ol_config_proxy_set_bool (config, "OSD/visible",
-                            !ol_config_proxy_get_bool (config, "OSD/visible"));
+  ol_config_proxy_set_bool (config, "General/display-mode-osd",
+                            !ol_config_proxy_get_bool (config, "General/display-mode-osd"));
 }

--- a/src/ol_commands.h
+++ b/src/ol_commands.h
@@ -36,9 +36,9 @@
 void ol_osd_lock_unlock ();
 
 /** 
- * @brief switch show/hide status
+ * @brief switch show/hide OSD
  * 
  */
-void ol_show_hide ();
+void ol_osd_switch_display ();
 
 #endif /* _OL_COMMANDS_H_ */

--- a/src/ol_config_property.h
+++ b/src/ol_config_property.h
@@ -108,7 +108,7 @@ static const OlConfigStrListValue config_str_list[] = {
 
 static const OlConfigBoolValue config_bool[] = {
   {"OSD/locked", TRUE},
-  {"OSD/visible", TRUE},
+  {"OSD/visible_when_stopped", TRUE},
   {"OSD/translucent-on-mouse-over", TRUE},
   {"Download/download-first-lyric", FALSE},
   {"General/display-mode-osd", TRUE},

--- a/src/ol_keybindings.c
+++ b/src/ol_keybindings.c
@@ -39,19 +39,19 @@ ol_keybinding_init ()
   GClosure *hide_closure = g_cclosure_new ((GCallback)ol_hide_accel,
                                            NULL,
                                            NULL);
-  gtk_accel_map_add_entry ("<OSD Lyrics>/Hide",
+  gtk_accel_map_add_entry ("<OSD Lyrics>/Switch OSD",
                            gdk_keyval_from_name ("h"),
                            GDK_CONTROL_MASK | GDK_SHIFT_MASK);
   gtk_accel_group_connect_by_path (accel,
-                                   "<OSD Lyrics>/Hide",
+                                   "<OSD Lyrics>/Switch OSD",
                                    hide_closure);
   gtk_accel_map_add_entry ("<OSD Lyrics>/Lock",
                            gdk_keyval_from_name ("l"),
                            GDK_CONTROL_MASK | GDK_SHIFT_MASK);
   gtk_accel_group_connect_by_path (accel,
-                                   "<OSD Lyrics>/Hide",
+                                   "<OSD Lyrics>/Switch OSD",
                                    hide_closure);
-  ol_keybinder_bind ("<Ctrl><Shift>H", ol_show_hide, NULL);
+  ol_keybinder_bind ("<Ctrl><Shift>H", ol_osd_switch_display, NULL);
   ol_keybinder_bind ("<Ctrl><Shift>L", ol_osd_lock_unlock, NULL);
 }
 

--- a/src/ol_menu.c
+++ b/src/ol_menu.c
@@ -219,7 +219,7 @@ ol_menu_hide (GtkWidget *widget, gpointer data)
   OlConfigProxy *config = ol_config_proxy_get_instance ();
   ol_assert (config != NULL);
   gboolean hide = gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (widget));
-  ol_config_proxy_set_bool (config, "OSD/visible", !hide);
+  ol_config_proxy_set_bool (config, "OSD/visible_when_stopped", !hide);
 }
 
 void
@@ -321,12 +321,6 @@ ol_menu_init ()
   }
 
   menu.hide = ol_gui_get_widget ("menu-hide");
-  if (menu.hide)
-  {
-    gtk_menu_item_set_accel_path (GTK_MENU_ITEM (menu.hide),
-                                  "<OSD Lyrics>/Hide");
-  }
-
   menu.preference = ol_gui_get_widget ("menu-prefernce");
   menu.about = ol_gui_get_widget ("menu-about");
   menu.quit = ol_gui_get_widget ("menu-quit");
@@ -338,11 +332,17 @@ ol_menu_init ()
   menu.next = ol_gui_get_widget ("menu-next");
 
   menu.switch_osd = ol_gui_get_widget ("menu-switch-osd");
+  if (menu.switch_osd)
+  {
+    gtk_menu_item_set_accel_path (GTK_MENU_ITEM (menu.switch_osd),
+                                  "<OSD Lyrics>/Switch OSD");
+  }
+
   menu.switch_scroll = ol_gui_get_widget ("menu-switch-scroll");
   
   gtk_widget_show_all (popup_menu);
   _locked_changed_cb (config, "OSD/locked", NULL);
-  _visible_changed_cb (config, "OSD/visible", NULL);
+  _visible_changed_cb (config, "OSD/visible_when_stopped", NULL);
   _display_mode_osd_changed_cb (config, "General/display-mode-osd", NULL);
   _display_mode_scroll_changed_cb (config, "General/display-mode-scroll", NULL);
   g_signal_connect (config,
@@ -350,7 +350,7 @@ ol_menu_init ()
                     G_CALLBACK (_locked_changed_cb),
                     NULL);
   g_signal_connect (config,
-                    "changed::OSD/visible",
+                    "changed::OSD/visible_when_stopped",
                     G_CALLBACK (_visible_changed_cb),
                     NULL);
   g_signal_connect (config,

--- a/src/ol_osd_toolbar.h
+++ b/src/ol_osd_toolbar.h
@@ -64,7 +64,4 @@ GtkWidget *ol_osd_toolbar_new (void);
 void ol_osd_toolbar_set_player (OlOsdToolbar *toolbar, OlPlayer *player);
 void ol_osd_toolbar_set_status (OlOsdToolbar *toolbar, enum OlPlayerStatus status);
 
-void ol_osd_toolbar_set_window_visibility(OlOsdToolbar *toolbar,
-                                          gboolean window_visible);
-
 #endif /* _OL_OSD_TOOLBAR_H_ */

--- a/src/ol_trayicon.c
+++ b/src/ol_trayicon.c
@@ -28,6 +28,7 @@
 #include "ol_stock.h"
 #include "ol_player.h"
 #include "ol_config_proxy.h"
+#include "ol_commands.h"
 #include "ol_debug.h"
 #include <gtk/gtkstatusicon.h>
 #include <gtk/gtktooltip.h>
@@ -54,9 +55,7 @@ static void
 activate (GtkStatusIcon* status_icon,
           gpointer user_data)
 {
-  OlConfigProxy *config = ol_config_proxy_get_instance ();
-  ol_config_proxy_set_bool (config, "OSD/visible",
-                            !ol_config_proxy_get_bool (config, "OSD/visible"));
+  ol_osd_switch_display ();
 }
 
 static gboolean


### PR DESCRIPTION
Right now we have two rather redundant mechanisms:
- Switching the OSD window (creating/destroying it)
- Hiding the OSD window

There isn't really a good reason to have both, unless you are hiding the
OSD temporarily quite often (faster than creating/destroying the
window). From experience this is typically because you are not playing
anything and you want the OSD window out of the way.

Well, maybe the best thing is simply not to show the OSD window when the
player is stopped, and this way it makes sense to have two mechanisms :)

This commit is really doing two things:
1. OSD/visible becomes OSD/visible_when_stopped and its meaning changes
   accordingly. To achieve that behaviour, the "status-changed" callback
   is moved from ol_osd_toolbar to ol_osd_module, and the module then
   feeds status updates to the toolbar.
2. The shortcuts to hide the OSD (Ctrl-Shift-H and clicking on the tray
   icon) now trigger the OSD switching mechanism
   (General/display-mode-osd) instead. This way they broadly do the same
   thing as before. There is clearly no point in having shortcuts for
   OSD/visible_when_stopped, as it is something you probably never
   change once configured.

Note: this partially reverts commit ece28b2a3079 ("ol_osd: fix show/hide
glitch"), indeed a nice side-effect of driving the toolbar status
updates from the module is that we no longer need to deal with the bug
this commit was trying to fix. Also, fun fact,
ol_osd_toolbar_set_status() is not added to the header as it is already
there! That function was introduced a long time ago, then removed, but
stayed in the header. So a bit more partial reverting there.