### PR TITLE
players: Fix position update when seeking

### DIFF
--- a/players/http/http-player.py
+++ b/players/http/http-player.py
@@ -132,8 +132,7 @@ class HttpPlayer(BasePlayer):
         self.status_changed()
 
     def do_update_position(self, pos):
-        if self._timer.set_time(pos):
-            self.position_changed()
+        self.position_changed(pos)
 
     def get_metadata(self):
         return self._metadata

--- a/players/mpris2/mpris2.py
+++ b/players/mpris2/mpris2.py
@@ -140,7 +140,7 @@ class Mpris2Player(BasePlayer):
                 getattr(self, method)()
 
     def _player_seeked(self, position):
-        self.position_changed()
+        self.position_changed(position // 1000)
 
     @property
     def object_path(self):

--- a/python/player_proxy.py
+++ b/python/player_proxy.py
@@ -752,10 +752,10 @@ class BasePlayer(DBusObject):
                 if cap in orig_caps != cap in self._caps:
                     setattr(self, method, cap in self._caps)
 
-    def position_changed(self):
+    def position_changed(self, position):
         """
         Notify that the position has been changed
         """
         if self._timer is not None:
-            self._timer.time = self.get_position()
-        self.Seeked(self._timer.time * 1000)
+            self._timer.time = position
+        self.Seeked(position * 1000)


### PR DESCRIPTION
The way the position is updated when we get a "Seeked" signal from an
MPRIS2 player is rather convoluted: we discard the position provided by
the signal, and instead update the position by asking the player again.

This is clearly suboptimal (unnecessary D-Bus call), but it turns out to
be unreliable as well: it is possible that the player will return a
stale position if asked just after seeking. As a result, OSD Lyrics
sometimes gets (completely) out of sync when the player is seeked. I've
seen this issue with gmusicbrowser but I may well affect other players
too.

This commit does the obvious: instead of asking the player again, just
forward the position provided by the signal to position_changed().
HttpPlayer is also changed accordingly (and the timer code removed as it
is redundant with position_changed()).