### PR TITLE
remove 99% of Python2 support

### DIFF
--- a/daemon/ini_config.py
+++ b/daemon/ini_config.py
@@ -18,10 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str, super
-
 import configparser
 
 import dbus

--- a/daemon/lrcdb.py
+++ b/daemon/lrcdb.py
@@ -17,11 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from __future__ import unicode_literals
-from future import standard_library
-standard_library.install_aliases()
-from builtins import object
-
 import logging
 import os.path
 import sqlite3
@@ -48,7 +43,7 @@ def query_param_from_metadata(metadata):
     return param
 
 
-class LrcDb(object):
+class LrcDb:
     """ Database to store location of LRC files that have been manually assigned
     """
 

--- a/daemon/lyrics.py
+++ b/daemon/lyrics.py
@@ -18,10 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from builtins import super
-from future import standard_library
-standard_library.install_aliases()
-
 import logging
 import os
 import os.path

--- a/daemon/lyricsource.py
+++ b/daemon/lyricsource.py
@@ -18,8 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from builtins import str, super
-
 import logging
 
 import dbus

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from __future__ import print_function
-from builtins import super
-
 import logging
 
 import dbus

--- a/daemon/player.py
+++ b/daemon/player.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from builtins import str, super
-
 import logging
 
 from dbus.exceptions import DBusException

--- a/lyricsources/megalobiz/megalobiz.py
+++ b/lyricsources/megalobiz/megalobiz.py
@@ -18,9 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str, super
 from urllib.parse import unquote
 
 import urllib.parse

--- a/lyricsources/netease/netease.py
+++ b/lyricsources/netease/netease.py
@@ -1,8 +1,3 @@
-from __future__ import unicode_literals
-from future import standard_library
-standard_library.install_aliases()
-from builtins import map, str, super
-
 import gettext
 import http.client
 import json

--- a/lyricsources/netease_tr/netease_tr.py
+++ b/lyricsources/netease_tr/netease_tr.py
@@ -1,8 +1,3 @@
-from __future__ import unicode_literals
-from future import standard_library
-standard_library.install_aliases()
-from builtins import map, str, super
-
 import gettext
 import http.client
 import json

--- a/lyricsources/subtitles4songs/subtitles4songs.py
+++ b/lyricsources/subtitles4songs/subtitles4songs.py
@@ -18,9 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str, super
 from urllib.parse import unquote
 
 # import urlparse

--- a/lyricsources/xiami/xiami.py
+++ b/lyricsources/xiami/xiami.py
@@ -18,10 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str, super
-
 # import urlparse
 import gettext
 import html.parser

--- a/players/http/error.py
+++ b/players/http/error.py
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from future import standard_library
-standard_library.install_aliases()
-
 import http.client
 
 

--- a/players/http/http-player.py
+++ b/players/http/http-player.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from builtins import super
-
 import datetime
 import logging
 import time

--- a/players/http/server.py
+++ b/players/http/server.py
@@ -18,9 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from future import standard_library
-standard_library.install_aliases()
-
 import http.server
 import json
 import logging

--- a/players/http/validator.py
+++ b/players/http/validator.py
@@ -18,8 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from builtins import object
-
 from error import BadRequestError
 
 __all__ = (
@@ -32,7 +30,7 @@ __all__ = (
 )
 
 
-class baseparam(object):
+class baseparam:
     def __init__(self, optional=False):
         self.optional = optional
 

--- a/players/mpd/mpd_proxy.py
+++ b/players/mpd/mpd_proxy.py
@@ -20,9 +20,6 @@
 
 """MPD support for OSD Lyrics. Requires MPD >= 0.16 and mpd-python >= 0.3
 """
-from __future__ import unicode_literals
-from builtins import object, super
-
 import logging
 import os
 import select
@@ -54,7 +51,7 @@ class NoConnectionError(Exception):
     pass
 
 
-class CommandCallback(object):
+class CommandCallback:
     def __init__(self, command, callback):
         self.command = command
         self.callback = callback
@@ -64,7 +61,7 @@ class CommandCallback(object):
             self.callback(*args)
 
 
-class Cmds(object):
+class Cmds:
     CONFIG = 'config'
     CURRENTSONG = 'currentsong'
     IDLE = 'idle'

--- a/players/mpris1/mpris1.py
+++ b/players/mpris1/mpris1.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from builtins import str, super
-
 from contextlib import contextmanager
 import logging
 

--- a/players/mpris2/mpris2.py
+++ b/players/mpris2/mpris2.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from builtins import str, super
-
 import logging
 
 import dbus

--- a/python/app.py
+++ b/python/app.py
@@ -18,8 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from builtins import object
-
 from optparse import OptionParser
 
 import dbus
@@ -42,7 +40,7 @@ class AlreadyRunningException(Exception):
     pass
 
 
-class App(object):
+class App:
     """ Basic class to create a component application for OSD Lyrics.
 
     The application creates a mainloop, owns a DBus name, and exits when the bus

--- a/python/config.py
+++ b/python/config.py
@@ -18,8 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from builtins import object
-
 import logging
 
 import dbus
@@ -29,7 +27,7 @@ from .consts import CONFIG_BUS_NAME, CONFIG_OBJECT_PATH
 CONFIG_INTERFACE = 'org.osdlyrics.Config'
 
 
-class Config(object):
+class Config:
     """ Helper class to retrive configs from OSD Lyrics through DBus
 
     It provides a set of get_<type> functions to get config values with default

--- a/python/dbusext/property.py
+++ b/python/dbusext/property.py
@@ -18,8 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from builtins import object, str
-
 import dbus.exceptions
 
 
@@ -28,7 +26,7 @@ class AccessDeniedError(dbus.exceptions.DBusException):
         dbus.exceptions.DBusException.__init__(self, dbus_error_name='org.osdlyrics.Error.AccessDenied', *args)
 
 
-class Property(object):
+class Property:
     """ DBus property class
     """
 

--- a/python/dbusext/service.py
+++ b/python/dbusext/service.py
@@ -30,10 +30,7 @@ from gi.repository import GLib
 
 from .property import Property
 
-# Use the default encoding in ElementTree.tostring under Python 2, but prefer
-# Unicode under Python 3 to obtain a 'str', not 'bytes' instance.
-# TODO: remove once we have fully migrated to Python 3
-INTROSPECT_ENCODING = 'unicode' if sys.version_info >= (3, 0) else 'us-ascii'
+INTROSPECT_ENCODING = 'unicode'
 
 
 class ObjectTypeCls(dbus.service.InterfaceType, ABCMeta):

--- a/python/errors.py
+++ b/python/errors.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from builtins import super
 
 import dbus.exceptions
 

--- a/python/lrc.py
+++ b/python/lrc.py
@@ -18,9 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
-from builtins import object
-
 import re
 
 import dbus.types
@@ -39,7 +36,7 @@ TIMESTAMP_PATTERN = re.compile(r'^\[(\d+(:\d+){0,2}(\.\d+)?)\]$')
 ATTR_PATTERN = re.compile(r'^\[([\w\d]+):(.*)\]$')
 
 
-class AttrToken(object):
+class AttrToken:
     """
     Represents tags with the form of ``[key:value]``
     """

--- a/python/lyricsource.py
+++ b/python/lyricsource.py
@@ -18,10 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import chr, object, range, str, super
-
 import logging
 import threading
 
@@ -52,7 +48,7 @@ def onmainthread(func):
     return decfunc
 
 
-class SearchResult(object):
+class SearchResult:
     """ Lyrics that match the metadata to be searched.
     """
 

--- a/python/metadata.py
+++ b/python/metadata.py
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from __future__ import unicode_literals
-from builtins import object
-
 import logging
 import re
 
@@ -28,7 +25,7 @@ import dbus
 from .consts import METADATA_ALBUM, METADATA_ARTIST, METADATA_TITLE
 
 
-class Metadata(object):
+class Metadata:
     """
     Metadata of a track
 

--- a/python/pattern.py
+++ b/python/pattern.py
@@ -17,11 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from __future__ import unicode_literals
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-
 import os.path
 import urllib.parse
 import urllib.request

--- a/python/player_proxy.py
+++ b/python/player_proxy.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from __future__ import unicode_literals
-from builtins import object, super
 from future.utils import raise_from
 
 from abc import abstractmethod
@@ -34,7 +32,7 @@ from .consts import (MPRIS2_PLAYER_INTERFACE, PLAYER_PROXY_INTERFACE,
 from .dbusext.service import Object as DBusObject, property as dbus_property
 
 
-class CAPS(object):
+class CAPS:
     NEXT = 1 << 0
     PREV = 1 << 1
     PAUSE = 1 << 2
@@ -43,13 +41,13 @@ class CAPS(object):
     PROVIDE_METADATA = 1 << 5
 
 
-class REPEAT(object):
+class REPEAT:
     NONE = 0
     TRACK = 1
     ALL = 2
 
 
-class STATUS(object):
+class STATUS:
     PLAYING = 0
     PAUSED = 1
     STOPPED = 2
@@ -172,7 +170,7 @@ class BasePlayerProxy(dbus.service.Object):
         raise NotImplementedError()
 
 
-class PlayerInfo(object):
+class PlayerInfo:
     """Information about a supported player
     """
 

--- a/python/timer.py
+++ b/python/timer.py
@@ -17,12 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from builtins import object
-
 from datetime import datetime
 
 
-class Timer(object):
+class Timer:
     """ A timer to account the elapsed playing.
     """
 

--- a/python/utils.py
+++ b/python/utils.py
@@ -17,11 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
-from __future__ import unicode_literals
-from future import standard_library
-standard_library.install_aliases()
-from builtins import object, str
-
 import io
 import os
 import os.path
@@ -42,14 +37,8 @@ __all__ = (
 
 pycurl.global_init(pycurl.GLOBAL_DEFAULT)
 
-if sys.version_info < (3, 0):
-    # make sure the default encoding is utf-8
-    if sys.getdefaultencoding() != 'utf-8':
-        reload(sys)
-        sys.setdefaultencoding('utf-8')
 
-
-class ProxySettings(object):
+class ProxySettings:
     """
     """
 

--- a/tools/create-lyricsource.py
+++ b/tools/create-lyricsource.py
@@ -18,9 +18,6 @@
 # along with OSD Lyrics.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
-from builtins import input
-
 import os
 import os.path
 import re
@@ -56,10 +53,6 @@ Exec=@PYTHON@ @pkglibdir@/lyricsources/${name}/${name}.py
 """
 
 PYTHON = r"""# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from builtins import super
-from future import standard_library
-standard_library.install_aliases()
 
 import http.client
 


### PR DESCRIPTION
Hi,

python3-future is not compatible with Python3.12 and will likely never be.

This legacy library is being removed from Debian.

Please consider dropping both `future` usage and Python2.7 support.

It remains exactly one call to fix: `raise_from`